### PR TITLE
Fixwritezeros

### DIFF
--- a/gadget/params.c
+++ b/gadget/params.c
@@ -149,13 +149,8 @@ create_gadget_parameter_set()
     param_declare_double(ps, "MaxNumNgbDeviation", OPTIONAL, 0.5, "Maximal deviation from the desired number of neighbours for each SPH particle.");
     param_declare_double(ps, "HydroCostFactor", OPTIONAL, 1, "Unused.");
 
-    param_declare_int(ps, "BytesPerFile", OPTIONAL, 1024 * 1024 * 1024, "number of bytes per file");
-    param_declare_int(ps, "NumWriters", OPTIONAL, 0, "Max number of concurrent writer processes. 0 implies Number of Tasks; ");
-    param_declare_int(ps, "MinNumWriters", OPTIONAL, 1, "Min number of concurrent writer processes. We increase number of Files to avoid too few writers. ");
-    param_declare_int(ps, "WritersPerFile", OPTIONAL, 8, "Number of Writer groups assigned to a file; total number of writers is capped by NumWriters.");
-
-    param_declare_int(ps, "EnableAggregatedIO", OPTIONAL, 1, "Reduces the number of open files in snapshots so that each file has size BytesPerFile.");
-    param_declare_int(ps, "AggregatedIOThreshold", OPTIONAL, 256, "Max size (in MB) on a writer before reverting to throttled IO.");
+    param_declare_int(ps, "BytesPerFile", OPTIONAL, 512 * 1024 * 1024, "Minimum number of bytes per file");
+    param_declare_int(ps, "NumWriters", OPTIONAL, 0, "Max number of concurrent writer processes. <= 0 implies Number of Tasks; ");
 
     /*Parameters of the cooling module*/
     param_declare_int(ps, "CoolingOn", REQUIRED, 0, "Enables cooling");

--- a/libgadget/petaio.c
+++ b/libgadget/petaio.c
@@ -31,12 +31,9 @@
  *
  */
 static struct petaio_params {
-    size_t BytesPerFile;   /* Number of bytes per physical file; this decides how many files bigfile creates each block */
-    int WritersPerFile;    /* Number of concurrent writers per file; this decides number of writers */
-    int NumWriters;        /* Number of concurrent writers, this caps number of writers */
-    int MinNumWriters;        /* Min Number of concurrent writers, this caps number of writers */
-    int EnableAggregatedIO;  /* Enable aggregated IO policy for small files.*/
-    size_t AggregatedIOThreshold; /* bytes per writer above which to use non-aggregated IO (avoid OOM)*/
+    size_t MinBytesPerFile;   /* Minimum number of bytes per physical file; instead of writing thousands of small files,
+                               * bigfile will create a single file and multiple ranks will write to it in turn */
+    int MaxIORanks;        /* Number of concurrent writers or readers, this caps the number of ranks doing IO at once. Defaults to number of tasks. */
     /* Changes the comoving factors of the snapshot outputs. Set in the ICs.
      * If UsePeculiarVelocity = 1 then snapshots save to the velocity field the physical peculiar velocity, v = a dx/dt (where x is comoving distance).
      * If UsePeculiarVelocity = 0 then the velocity field is a * v = a^2 dx/dt in snapshots
@@ -63,15 +60,12 @@ set_petaio_params(ParameterSet * ps)
     int ThisTask;
     MPI_Comm_rank(MPI_COMM_WORLD, &ThisTask);
     if(ThisTask == 0) {
-        IO.BytesPerFile = param_get_int(ps, "BytesPerFile");
+        IO.MinBytesPerFile = param_get_int(ps, "BytesPerFile");
         IO.UsePeculiarVelocity = 0; /* Will be set by the Initial Condition File */
-        IO.NumWriters = param_get_int(ps, "NumWriters");
-        IO.MinNumWriters = param_get_int(ps, "MinNumWriters");
-        IO.WritersPerFile = param_get_int(ps, "WritersPerFile");
-        IO.AggregatedIOThreshold = param_get_int(ps, "AggregatedIOThreshold");
-        /* Convert from MB to bytes*/
-        IO.AggregatedIOThreshold *= 1024L * 1024L;
-        IO.EnableAggregatedIO = param_get_int(ps, "EnableAggregatedIO");
+        IO.MaxIORanks = param_get_int(ps, "NumWriters");
+        if(IO.MaxIORanks <= 0)
+            MPI_Comm_size(MPI_COMM_WORLD, &IO.MaxIORanks);
+
         IO.OutputPotential = param_get_int(ps, "OutputPotential");
         IO.OutputTimebins = param_get_int(ps, "OutputTimebins");
         IO.OutputHeliumFractions = param_get_int(ps, "OutputHeliumFractions");
@@ -89,20 +83,6 @@ int GetUsePeculiarVelocity(void)
 
 static void petaio_write_header(BigFile * bf, const double atime, const int64_t * NTotal, const Cosmology * CP, const struct header_data * data);
 static void petaio_read_header_internal(BigFile * bf, Cosmology * CP, struct header_data * data);
-
-/* these are only used in reading in */
-void petaio_init(void) {
-    /* Smaller files will do aggregated IO.*/
-    if(IO.EnableAggregatedIO) {
-        message(0, "Aggregated IO is enabled\n");
-        big_file_mpi_set_aggregated_threshold(IO.AggregatedIOThreshold);
-    } else {
-        message(0, "Aggregated IO is disabled.\n");
-        big_file_mpi_set_aggregated_threshold(0);
-    }
-    if(IO.NumWriters == 0)
-        MPI_Comm_size(MPI_COMM_WORLD, &IO.NumWriters);
-}
 
 /* Build a list of the first particle of each type on the current processor.
  * This assumes that all particles are sorted!*/
@@ -585,8 +565,8 @@ void petaio_destroy_buffer(BigArray * array) {
 
 /* read a block from disk, spread the values to memory with setters  */
 int petaio_read_block(BigFile * bf, const char * blockname, BigArray * array, int required) {
-    BigBlock bb;
-    BigBlockPtr ptr;
+    BigBlock bb = {0};
+    BigBlockPtr ptr = {0};
 
     /* open the block */
     if(0 != big_file_mpi_open_block(bf, &bb, blockname, MPI_COMM_WORLD)) {
@@ -598,7 +578,7 @@ int petaio_read_block(BigFile * bf, const char * blockname, BigArray * array, in
     if(0 != big_block_seek(&bb, &ptr, 0)) {
             endrun(1, "Failed to seek block %s: %s\n", blockname, big_file_get_error_message());
     }
-    if(0 != big_block_mpi_read(&bb, &ptr, array, IO.NumWriters, MPI_COMM_WORLD)) {
+    if(0 != big_block_mpi_read(&bb, &ptr, array, IO.MaxIORanks, MPI_COMM_WORLD)) {
         endrun(1, "Failed to read from block %s: %s\n", blockname, big_file_get_error_message());
     }
     if(0 != big_block_mpi_close(&bb, MPI_COMM_WORLD)) {
@@ -611,58 +591,32 @@ int petaio_read_block(BigFile * bf, const char * blockname, BigArray * array, in
 /* save a block to disk */
 void petaio_save_block(BigFile * bf, const char * blockname, BigArray * array, int verbose)
 {
-
-    BigBlock bb = {0};
-    BigBlockPtr ptr = {0};
-
-    int elsize = big_file_dtype_itemsize(array->dtype);
-
-    int NumWriters = IO.NumWriters;
-
     size_t size, count_local = array->dims[0];
     MPI_Allreduce(&count_local, &size, 1, MPI_INT64, MPI_SUM, MPI_COMM_WORLD);
-    int NumFiles;
 
-    if(IO.EnableAggregatedIO) {
-        NumFiles = (size * elsize + IO.BytesPerFile - 1) / IO.BytesPerFile;
-        if(NumWriters > NumFiles * IO.WritersPerFile) {
-            NumWriters = NumFiles * IO.WritersPerFile;
-        }
-        if(NumWriters < IO.MinNumWriters && IO.MinNumWriters > 1) {
-            if(NumWriters > 0)
-                message(0, "Throttling to %d NumWriters but could throttle to %d.\n", IO.MinNumWriters, NumWriters);
-            NumWriters = IO.MinNumWriters;
-            NumFiles = (NumWriters + IO.WritersPerFile - 1) / IO.WritersPerFile ;
-        }
-    } else {
-        NumFiles = NumWriters;
-    }
     /*Do not write empty files*/
     if(size == 0) {
-        NumFiles = 0;
         return;
     }
+    /* This defaults to the number of tasks.*/
+    int NumWriters = IO.MaxIORanks;
 
-    if(verbose && size > 0) {
-        message(0, "Will write %td particles to %d Files with %d writers for %s. \n", size, NumFiles, NumWriters, blockname);
+    int elsize = big_file_dtype_itemsize(array->dtype);
+    /* This makes sure the file size is not too small*/
+    int MaxNumFiles = (size * elsize + IO.MinBytesPerFile - 1) / IO.MinBytesPerFile;
+    if(NumWriters > MaxNumFiles)
+        NumWriters = MaxNumFiles;
+
+    if(verbose) {
+        message(0, "Will write %td particles with %d writers for %s. \n", size, NumWriters, blockname);
     }
-    /* create the block */
-    /* dims[1] is the number of members per item */
-    if(0 != big_file_mpi_create_block(bf, &bb, blockname, array->dtype, array->dims[1], NumFiles, size, MPI_COMM_WORLD)) {
-        endrun(0, "Failed to create block at %s:%s\n", blockname,
+    /* create and write the block */
+    if(0 != big_block_mpi_create_and_write(bf, blockname, array, NumWriters, MPI_COMM_WORLD)) {
+        endrun(0, "Failed to write block at %s:%s\n", blockname,
                     big_file_get_error_message());
     }
-    if(0 != big_block_mpi_write(&bb, &ptr, array, NumWriters, MPI_COMM_WORLD)) {
-        endrun(0, "Failed to write :%s\n", big_file_get_error_message());
-    }
-
-    if(verbose && size > 0)
-        message(0, "Done writing %td particles to %d Files\n", size, NumFiles);
-
-    if(0 != big_block_mpi_close(&bb, MPI_COMM_WORLD)) {
-        endrun(0, "Failed to close block at %s:%s\n", blockname,
-                big_file_get_error_message());
-    }
+    if(verbose)
+        message(0, "Done writing %td particles for %s\n", size, blockname);
 }
 
 /*

--- a/libgadget/petaio.h
+++ b/libgadget/petaio.h
@@ -75,7 +75,6 @@ void destroy_io_blocks(struct IOTable * IOTable);
 
 void set_petaio_params(ParameterSet *ps);
 int GetUsePeculiarVelocity(void);
-void petaio_init();
 void petaio_alloc_buffer(BigArray * array, IOTableEntry * ent, int64_t npartLocal);
 void petaio_build_buffer(BigArray * array, IOTableEntry * ent, const int * selection, const int NumSelection, struct particle_data * Parts, struct slots_manager_type * SlotsManager, struct conversions * conv);
 void petaio_readout_buffer(BigArray * array, IOTableEntry * ent, struct conversions * conv, struct part_manager_type * PartManager, struct slots_manager_type * SlotsManager);

--- a/libgadget/run.c
+++ b/libgadget/run.c
@@ -225,7 +225,6 @@ begrun(const int RestartSnapNum, struct header_data * head)
     mymalloc_init(All.UseGPU);
 
     petapm_module_init(omp_get_max_threads());
-    petaio_init();
     walltime_init(&Clocks);
 
     *head = petaio_read_header(RestartSnapNum, All.OutputDir, &All.CP);

--- a/src/bigfile-mpi.c
+++ b/src/bigfile-mpi.c
@@ -9,7 +9,6 @@
 
 /* disable aggregation by default */
 static size_t _BigFileAggThreshold = 0;
-static int _big_file_mpi_verbose = 0;
 
 static int big_block_mpi_broadcast(BigBlock * bb, int root, MPI_Comm comm);
 static int big_file_mpi_broadcast_anyerror(int rt, MPI_Comm comm);
@@ -22,7 +21,6 @@ static int big_file_mpi_broadcast_anyerror(int rt, MPI_Comm comm);
 void
 big_file_mpi_set_verbose(int verbose)
 {
-    _big_file_mpi_verbose = verbose;
 }
 
 void
@@ -389,16 +387,16 @@ _aggregated(
             ptrdiff_t offset, /* offset of the entire comm */
             size_t localsize,
             BigArray * array,
-            int (*action)(BigBlock * bb, BigBlockPtr * ptr, BigArray * array),
+            int write,
             int root,
+            const char * mode,
             MPI_Comm comm);
 
 static int
 _throttle_action(MPI_Comm comm, int concurrency, BigBlock * block,
     BigBlockPtr * ptr,
     BigArray * array,
-    int (*action)(BigBlock * bb, BigBlockPtr * ptr, BigArray * array)
-)
+    int write)
 {
     int ThisTask, NTask;
 
@@ -407,26 +405,25 @@ _throttle_action(MPI_Comm comm, int concurrency, BigBlock * block,
 
     MPIU_Segmenter seggrp[1];
 
-    if(concurrency <= 0) {
-        concurrency = NTask;
-    }
-
-    size_t avgsegsize;
+    size_t totalsize = 0;
     size_t localsize = array->dims[0];
-    size_t myoffset;
+    size_t myoffset = 0;
     size_t * sizes = (size_t *) malloc(sizeof(sizes[0]) * NTask);
+    sizes[ThisTask] = localsize;
 
-    size_t totalsize = MPIU_Segmenter_collect_sizes(localsize, sizes, &myoffset, comm);
+    MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, sizes, 1, MPI_UNSIGNED_LONG, comm);
+    int i;
+    for(i = 0; i < ThisTask; i ++)
+        myoffset += sizes[i];
+    for(i = 0; i < NTask; i ++)
+        totalsize += sizes[i];
 
-    /* try to create as many segments as number of groups (thus one segment per group) */
-    avgsegsize = totalsize / concurrency;
 
-    if(avgsegsize <= 0) avgsegsize = 1;
-
-    /* no segment shall exceed the memory bound set by maxsegsize, since it will be collected to a single rank */
-    if(avgsegsize > _BigFileAggThreshold) avgsegsize = _BigFileAggThreshold;
-
-    MPIU_Segmenter_init(seggrp, sizes, NULL, avgsegsize, concurrency, comm);
+    size_t minsegsize = 32 * 1024 * 1024;
+    /* Creates segments and groups. The number of groups is roughly equal
+     * to the number of writing processes (with a complexity if some processes have no data to write).
+     * The number of segments is set by the average size of data to write to a file.*/
+    MPIU_Segmenter_init(seggrp, sizes, totalsize, _BigFileAggThreshold, minsegsize, concurrency, comm);
 
     free(sizes);
 
@@ -437,20 +434,21 @@ _throttle_action(MPI_Comm comm, int concurrency, BigBlock * block,
         segment < seggrp->segment_end;
         segment ++) {
 
+        /* Ensures that ranks in this group, but not in this segment do not try to write at the same time*/
         MPI_Barrier(seggrp->Group);
 
+        /* This extra broadcast is so that the error-ing segment stops trying to write.*/
         if(0 != (rt = big_file_mpi_broadcast_anyerror(rt, seggrp->Group))) {
-            /* failed , abort. */
+            /* failed , no more writes to segment. */
             continue;
         }
         if(seggrp->ThisSegment != segment) continue;
 
         /* use the offset on the first task in the SegGroup */
         size_t offset = myoffset;
-        MPI_Bcast(&offset, 1, MPI_LONG, 0, seggrp->Segment);
+        MPI_Bcast(&offset, 1, MPI_UNSIGNED_LONG, 0, seggrp->Segment);
 
-        rt = _aggregated(block, ptr, offset, localsize, array, action, seggrp->segment_leader_rank, seggrp->Segment);
-
+        rt = _aggregated(block, ptr, offset, localsize, array, write, seggrp->segment_leader_rank, "r+", seggrp->Segment);
     }
 
     if(0 == (rt = big_file_mpi_broadcast_anyerror(rt, comm))) {
@@ -467,10 +465,11 @@ _aggregated(
             BigBlock * block,
             BigBlockPtr * ptr,
             ptrdiff_t offset, /* offset of the entire comm */
-            size_t localsize, /* offset of the entire comm */
+            size_t localsize,
             BigArray * array,
-            int (*action)(BigBlock * bb, BigBlockPtr * ptr, BigArray * array),
+            int write,
             int root,
+            const char * mode,
             MPI_Comm comm)
 {
     size_t elsize = big_file_dtype_itemsize(block->dtype) * block->nmemb;
@@ -500,13 +499,11 @@ _aggregated(
     recvcounts[rank] = localsize;
     MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, recvcounts, 1, MPI_INT, comm);
 
-    int grouptotalsize = localsize;
-
-    MPI_Allreduce(MPI_IN_PLACE, &grouptotalsize, 1, MPI_INT, MPI_SUM, comm);
-
     for(i = 0; i < nrank; i ++) {
         recvdispls[i + 1] = recvdispls[i] + recvcounts[i];
     }
+
+    size_t grouptotalsize = recvdispls[nrank];
 
     MPI_Datatype mpidtype;
     MPI_Type_contiguous(elsize, MPI_BYTE, &mpidtype);
@@ -519,19 +516,23 @@ _aggregated(
 
     if(rank == root) {
         gbuf = malloc(grouptotalsize * elsize);
-        big_array_init(garray, gbuf, block->dtype, 2, (size_t[]){(size_t) grouptotalsize, (size_t) block->nmemb}, NULL);
+        big_array_init(garray, gbuf, block->dtype, 2, (size_t[]){grouptotalsize, (size_t) block->nmemb}, NULL);
     }
 
-    if(action == big_block_write) {
+    if(write) {
         _dtype_convert(ilarray, iarray, localsize * block->nmemb);
         MPI_Gatherv(lbuf, recvcounts[rank], mpidtype,
                     gbuf, recvcounts, recvdispls, mpidtype, root, comm);
     }
     if(rank == root) {
         big_block_seek_rel(block, ptr1, offset);
-        e = action(block, ptr1, garray);
+        if(write)
+            e = _big_block_write_mode(block, ptr1, garray, mode);
+        else
+            e = big_block_read(block, ptr1, garray);
     }
-    if(action == big_block_read) {
+    /* We are a read*/
+    if(!write) {
         MPI_Scatterv(gbuf, recvcounts, recvdispls, mpidtype,
                     lbuf, localsize, mpidtype, root, comm);
         _dtype_convert(iarray, ilarray, localsize * block->nmemb);
@@ -548,16 +549,133 @@ _aggregated(
 }
 
 int
+big_block_mpi_create_and_write(BigFile * bf,
+        const char * blockname,
+        BigArray * array,
+        int concurrency,
+        MPI_Comm comm)
+{
+    int NTask, ThisTask;
+    int rt = 0;
+
+    if(comm == MPI_COMM_NULL) return 0;
+
+    MPI_Comm_size(comm, &NTask);
+    MPI_Comm_rank(comm, &ThisTask);
+
+    if (ThisTask == 0) {
+        rt = _big_file_mksubdir_r(bf->basename, blockname);
+    }
+
+    BCAST_AND_RAISEIF(rt, comm);
+
+    MPIU_Segmenter seggrp[1];
+
+    size_t totalsize = 0;
+    size_t localsize = array->dims[0];
+    size_t * sizes = (size_t *) malloc(sizeof(sizes[0]) * NTask);
+    sizes[ThisTask] = localsize;
+
+    MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, sizes, 1, MPI_UNSIGNED_LONG, comm);
+    int i;
+    for(i = 0; i < NTask; i ++)
+        totalsize += sizes[i];
+
+    /* For datasets smaller than some value, it is more efficient
+     * to gather them to one rank, rather than opening the file on each rank
+     * in the group in turn. The number here is not rigorously chosen, but is smaller
+     * than CHUNK_BYTES so we can definitely do it in one write*/
+    size_t minsegsize = 32 * 1024 * 1024;
+
+    /* Creates segments and groups. The number of groups is roughly equal
+     * to the number of writing processes (with a complexity if some processes have no data to write).
+     * We create one file per segment group.*/
+    MPIU_Segmenter_init(seggrp, sizes, totalsize, totalsize, minsegsize, concurrency, comm);
+
+    size_t group_total;
+    MPI_Allreduce(&sizes[ThisTask], &group_total, 1, MPI_UNSIGNED_LONG, MPI_SUM, seggrp->Group);
+    /* Work out the sizes of each group. This will become the sizes for the files*/
+    size_t * gsizes = calloc(seggrp->Ngroup, sizeof(size_t));
+    if(seggrp->GroupID < seggrp->Ngroup)
+        gsizes[seggrp->GroupID] = group_total;
+    /* At this point elements in the group have gsizes = group_total for their own group, and
+     * zero for the other groups. Propagate the group sizes below, noting we use MPI_MAX */
+    MPI_Allreduce(MPI_IN_PLACE, gsizes, seggrp->Ngroup, MPI_UNSIGNED_LONG, MPI_MAX, comm);
+
+    BigBlock block = {0};
+    if(ThisTask == 0) {
+        /* Now we know the groups and segments, create the files*/
+        size_t stringlen = strlen(bf->basename) + strnlen(blockname, 512) + 128;
+        char * basename = (char *) malloc(stringlen);
+        snprintf(basename, stringlen, "%s/%s/", bf->basename, blockname);
+        rt = _big_block_create_internal(&block, basename, array->dtype, array->dims[1], seggrp->Ngroup, gsizes);
+        free(basename);
+    }
+
+    size_t myoffset = 0;
+    for(i = 0; i < ThisTask; i ++)
+        myoffset += sizes[i];
+
+    free(gsizes);
+    free(sizes);
+
+    if(0 != (rt = big_file_mpi_broadcast_anyerror(rt, comm))) {
+        /* No need to close the block as if rt != 0 we didn't open it correctly*/
+        MPIU_Segmenter_destroy(seggrp);
+        return rt;
+    }
+
+    big_block_mpi_broadcast(&block, 0, comm);
+
+    BigBlockPtr ptr = {0};
+
+    int segment;
+
+    for(segment = seggrp->segment_start;
+        segment < seggrp->segment_end;
+        segment ++) {
+
+        /* Ensures that ranks in this group, but not in this segment do not try to write at the same time*/
+        MPI_Barrier(seggrp->Group);
+
+        /* This extra broadcast is so that the error-ing segment stops trying to write.*/
+        if(0 != (rt = big_file_mpi_broadcast_anyerror(rt, seggrp->Group))) {
+            /* failed , no more writes to segment. */
+            continue;
+        }
+        if(seggrp->ThisSegment != segment) continue;
+
+        /* use the offset on the first task in the SegGroup */
+        size_t offset = myoffset;
+        MPI_Bcast(&offset, 1, MPI_UNSIGNED_LONG, 0, seggrp->Segment);
+
+        /* write = 1 : Always writing here and we use mode 'w' so we create the files.*/
+        rt = _aggregated(&block, &ptr, offset, localsize, array, 1, seggrp->segment_leader_rank, "w", seggrp->Segment);
+    }
+
+    MPIU_Segmenter_destroy(seggrp);
+
+    /* Block written, close it: we need to close even if we have a write error,
+     * but we want to preserve the write error in that case.*/
+    int close_rt = big_block_mpi_close(&block, comm);
+    if(rt == 0)
+        rt = close_rt;
+    rt = big_file_mpi_broadcast_anyerror(rt, comm);
+    return rt;
+}
+
+
+int
 big_block_mpi_write(BigBlock * block, BigBlockPtr * ptr, BigArray * array, int concurrency, MPI_Comm comm)
 {
-    int rt = _throttle_action(comm, concurrency, block, ptr, array, big_block_write);
+    int rt = _throttle_action(comm, concurrency, block, ptr, array, 1);
     return rt;
 }
 
 int
 big_block_mpi_read(BigBlock * block, BigBlockPtr * ptr, BigArray * array, int concurrency, MPI_Comm comm)
 {
-    int rt = _throttle_action(comm, concurrency, block, ptr, array, big_block_read);
+    int rt = _throttle_action(comm, concurrency, block, ptr, array, 0);
     return rt;
 }
 

--- a/src/bigfile-mpi.h
+++ b/src/bigfile-mpi.h
@@ -94,10 +94,14 @@ int big_block_mpi_grow_simple(BigBlock * block, int Nfile_grow, size_t fsize_gro
  *  the data is aggregated to the leader rank of the writer group for writing, to reduce
  *  the total number of IO requests issued to the file server.
  *
+ * Note! Multiple writers may write to the same file at the same time! The filesystem
+ * locking needs to be reliable. This is a dangerous mode to use.
+ *
  * */
 void big_file_mpi_set_aggregated_threshold(size_t bytes);
 size_t big_file_mpi_get_aggregated_threshold();
 
+/* This function has no effect and is here only for API compatibility purposes.*/
 void big_file_mpi_set_verbose(int verbose);
 
 /** Write data stored in a BigArray to a BigBlock.
@@ -115,6 +119,27 @@ void big_file_mpi_set_verbose(int verbose);
  * @returns 0 if successful. */
 int big_block_mpi_write(BigBlock * bb, BigBlockPtr * ptr, BigArray * array, int concurrency, MPI_Comm comm);
 
+/** Create a BigBlock and write data stored in a BigArray to it.
+ * This is similar to doing big_file_mpi_create_block(),
+ * big_block_mpi_write() and big_block_mpi_close() in a single call.
+ *
+ * Using a single call allows us to enforce that each rank writes only to a single file.
+ * This is done by ensuring that file boundaries match up to rank boundaries.
+ * Useful especially when the parallel locking in the filesystem is not reliable.
+ *
+ * The BigBlock pointed to by blockname should not exist and will be destroyed if it does.
+ *
+ * This is a collective MPI operation.
+ *
+ * Arguments:
+ * @param bf - Opened BigFile
+ * @param blockname - the name of the block to create.
+ * @param array - BigArray containing the data which should be written.
+ * @param concurrency - Max number of MPI ranks that issues write operation at the same time and the number of files in the block.
+ * @param comm - MPI Communicator
+ * @returns 0 if successful. */
+int big_block_mpi_create_and_write(BigFile * bf, const char * blockname, BigArray * array, int concurrency, MPI_Comm comm);
+
 /** Read from a block to a BigArray
  *
  * This is a collective MPI operation. The read operation will start from ptr.
@@ -128,7 +153,7 @@ int big_block_mpi_write(BigBlock * bb, BigBlockPtr * ptr, BigArray * array, int 
  */
 int big_block_mpi_read(BigBlock * bb, BigBlockPtr * ptr, BigArray * array, int concurrency, MPI_Comm comm);
 
-/** Flush the BigBlock 
+/** Flush the BigBlock
  *
  *  Flush will write the attrset from root rank, and gather the checksums from all ranks.
  *

--- a/src/bigfile.c
+++ b/src/bigfile.c
@@ -798,8 +798,8 @@ big_block_read(BigBlock * bb, BigBlockPtr * ptr, BigArray * array)
 {
     char * chunkbuf = (char *) malloc(CHUNK_BYTES);
 
-    int nmemb = bb->nmemb ? bb->nmemb : 1;
-    int felsize = big_file_dtype_itemsize(bb->dtype) * nmemb;
+    int64_t nmemb = bb->nmemb ? bb->nmemb : 1;
+    int64_t felsize = big_file_dtype_itemsize(bb->dtype) * nmemb;
     size_t CHUNK_SIZE = CHUNK_BYTES / felsize;
 
     BigArray chunk_array = {0};
@@ -828,6 +828,14 @@ big_block_read(BigBlock * bb, BigBlockPtr * ptr, BigArray * array)
                 ex_eof,
                 "Reading beyond the block `%s` at (%d:%td)",
                 bb->basename, ptr->fileid, ptr->roffset * felsize);
+    fp = _big_file_open_a_file(bb->basename, ptr->fileid, "r", 1);
+    RAISEIF(fp == NULL,
+            ex_open,
+            NULL);
+    RAISEIF(0 > fseek(fp, ptr->roffset * felsize, SEEK_SET),
+            ex_seek,
+            "Failed to seek in block `%s' at (%d:%td) (%s)",
+            bb->basename, ptr->fileid, ptr->roffset * felsize, strerror(errno));
 
     while(toread > 0 && ! big_block_eof(bb, ptr)) {
         size_t chunk_size = CHUNK_SIZE;
@@ -847,39 +855,40 @@ big_block_read(BigBlock * bb, BigBlockPtr * ptr, BigArray * array)
         /* read to the beginning of chunk */
         big_array_iter_init(&chunk_iter, &chunk_array);
 
-        fp = _big_file_open_a_file(bb->basename, ptr->fileid, "r", 1);
-        RAISEIF(fp == NULL,
-                ex_open,
-                NULL);
-        RAISEIF(0 > fseek(fp, ptr->roffset * felsize, SEEK_SET),
-                ex_seek,
-                "Failed to seek in block `%s' at (%d:%td) (%s)",
-                bb->basename, ptr->fileid, ptr->roffset * felsize, strerror(errno));
         RAISEIF(chunk_size != fread(chunkbuf, felsize, chunk_size, fp),
                 ex_read,
                 "Failed to read in block `%s' at (%d:%td) (%s)",
                 bb->basename, ptr->fileid, ptr->roffset * felsize, strerror(errno));
-        fclose(fp);
-        fp = NULL;
 
         /* now translate the data from chunkbuf to mptr */
         RAISEIF(0 != _dtype_convert(&array_iter, &chunk_iter, chunk_size * bb->nmemb),
             ex_convert, NULL);
 
         toread -= chunk_size;
+        /* big_block_seek may change the fileid (because the physical file is full up)
+         * Check for this case and re-open the new file*/
+        int fileid = ptr->fileid;
         RAISEIF(0 != big_block_seek_rel(bb, ptr, chunk_size),
                 ex_blockseek,
                 NULL);
+        if(ptr->fileid != fileid) {
+            fclose(fp);
+            fp = _big_file_open_a_file(bb->basename, ptr->fileid, "r", 1);
+            RAISEIF(fp == NULL,
+                ex_open,
+                NULL);
+        }
     }
 
+    fclose(fp);
     free(chunkbuf);
     return 0;
 ex_read:
 ex_seek:
-    fclose(fp);
 ex_insuf:
 ex_convert:
 ex_blockseek:
+    fclose(fp);
 ex_open:
 ex_eof:
     free(chunkbuf);
@@ -889,12 +898,17 @@ ex_eof:
 int
 big_block_write(BigBlock * bb, BigBlockPtr * ptr, BigArray * array)
 {
+    return _big_block_write_mode(bb, ptr, array, "r+");
+}
+
+int
+_big_block_write_mode(BigBlock * bb, BigBlockPtr * ptr, BigArray * array, const char * mode)
+{
     if(array->size == 0) return 0;
     /* the file header is modified */
     bb->dirty = 1;
-    char * chunkbuf = (char *) malloc(CHUNK_BYTES);
-    int nmemb = bb->nmemb ? bb->nmemb : 1;
-    int felsize = big_file_dtype_itemsize(bb->dtype) * nmemb;
+    int64_t nmemb = bb->nmemb ? bb->nmemb : 1;
+    int64_t felsize = big_file_dtype_itemsize(bb->dtype) * nmemb;
     size_t CHUNK_SIZE = CHUNK_BYTES / felsize;
 
     BigArray chunk_array = {0};
@@ -904,26 +918,54 @@ big_block_write(BigBlock * bb, BigBlockPtr * ptr, BigArray * array)
 
     BigArrayIter chunk_iter;
     BigArrayIter array_iter;
-    ptrdiff_t towrite = 0;
-    FILE * fp;
 
+    char * chunkbuf = (char *) malloc(CHUNK_BYTES);
     if(chunkbuf == NULL) {
-        _big_file_raise("not enough memory for chunkbuf of size %d bytes", __FILE__, __LINE__,  CHUNK_BYTES);
+        _big_file_raise("not enough memory for chunkbuf of size %zu bytes", __FILE__, __LINE__,  CHUNK_BYTES);
         return -1;
     }
 
     big_array_init(&chunk_array, chunkbuf, bb->dtype, 2, dims, NULL);
     big_array_iter_init(&array_iter, array);
 
-    towrite = array->size / nmemb;
+    ptrdiff_t towrite = array->size / nmemb;
 
     ptrdiff_t abs = bb->foffset[ptr->fileid] + ptr->roffset + towrite;
-    RAISEIF(abs > bb->size,
-                ex_eof,
-                "Writing beyond the block `%s` at (%d:%td)",
-                bb->basename, ptr->fileid, ptr->roffset * felsize);
+    if(abs > bb->size) {
+        free(chunkbuf);
+        _big_file_raise("Writing beyond the block `%s` at (%d:%td)", __FILE__, __LINE__,
+        bb->basename, ptr->fileid, ptr->roffset * felsize);
+        return -1;
+    }
+    FILE * fp = _big_file_open_a_file(bb->basename, ptr->fileid, mode, 1);
+    if(fp == NULL) {
+        free(chunkbuf);
+        _big_file_raise("Could not open file '%s:%d'", __FILE__, __LINE__,  bb->basename, ptr->fileid);
+        return -1;
+    }
+    int fileid = ptr->fileid;
+
+    RAISEIF(0 > fseek(fp, ptr->roffset * felsize, SEEK_SET),
+        ex_seek,
+        "Failed to seek in block `%s' at (%d:%td) (%s)",
+        bb->basename, ptr->fileid, ptr->roffset * felsize, strerror(errno));
 
     while(towrite > 0 && ! big_block_eof(bb, ptr)) {
+        if(ptr->fileid != fileid) {
+            fclose(fp);
+            if(strcmp(mode, "r+") != 0) {
+                free(chunkbuf);
+                _big_file_raise("Opened second file with mode w in one call, not allowed: '%d->%d'", __FILE__, __LINE__,  fileid, ptr->fileid);
+                return -1;
+            }
+            fp = _big_file_open_a_file(bb->basename, ptr->fileid, mode, 1);
+            if(fp == NULL) {
+                free(chunkbuf);
+                _big_file_raise("Could not open file '%s:%d'", __FILE__, __LINE__,  bb->basename, ptr->fileid);
+                return -1;
+            }
+            fileid = ptr->fileid;
+        }
         size_t chunk_size = CHUNK_SIZE;
         /* remaining items in the file */
         if(chunk_size > bb->fsize[ptr->fileid] - ptr->roffset) {
@@ -940,37 +982,27 @@ big_block_write(BigBlock * bb, BigBlockPtr * ptr, BigArray * array)
         RAISEIF(0 != _dtype_convert(&chunk_iter, &array_iter, chunk_size * bb->nmemb),
             ex_convert, NULL);
 
-        sysvsum(&bb->fchecksum[ptr->fileid], chunkbuf, chunk_size * felsize);
-
-        fp = _big_file_open_a_file(bb->basename, ptr->fileid, "r+", 1);
-        RAISEIF(fp == NULL,
-                ex_open,
-                NULL);
-        RAISEIF(0 > fseek(fp, ptr->roffset * felsize, SEEK_SET),
-                ex_seek,
-                "Failed to seek in block `%s' at (%d:%td) (%s)",
-                bb->basename, ptr->fileid, ptr->roffset * felsize, strerror(errno));
         RAISEIF(chunk_size != fwrite(chunkbuf, felsize, chunk_size, fp),
                 ex_write,
                 "Failed to write in block `%s' at (%d:%td) (%s)",
                 bb->basename, ptr->fileid, ptr->roffset * felsize, strerror(errno));
-        fclose(fp);
+        sysvsum(&bb->fchecksum[ptr->fileid], chunkbuf, chunk_size * felsize);
 
         towrite -= chunk_size;
+        /* big_block_seek may change the fileid (because the physical file is full up)
+         * Check for this case and re-open the new file*/
         RAISEIF(0 != big_block_seek_rel(bb, ptr, chunk_size),
                 ex_blockseek, NULL);
     }
+    fclose(fp);
     free(chunkbuf);
     return 0;
 ex_write:
 ex_seek:
-    fclose(fp);
 ex_convert:
-ex_open:
 ex_blockseek:
-ex_eof:
+    fclose(fp);
     free(chunkbuf);
-ex_malloc:
     return -1;
 }
 
@@ -1501,8 +1533,7 @@ attrset_read_attr_set_v2(BigAttrSet * attrset, const char * basename)
     }
     char * buffer = (char*) malloc(size + 1);
     unsigned char * data = (unsigned char * ) malloc(size + 1);
-    RAISEIF(!buffer, ex_init, "Could not allocate memory for buffer: %ld bytes",size+1);
-    RAISEIF(!data, ex_data, "Could not allocate memory for data: %ld bytes",size+1);
+    RAISEIF((!buffer) || (!data), ex_init, "Could not allocate memory for data or buffer: %ld bytes",2 * (size+1));
     fseek(fattr, 0, SEEK_SET);
     RAISEIF(size != fread(buffer, 1, size, fattr),
             ex_read_file,
@@ -1511,10 +1542,11 @@ attrset_read_attr_set_v2(BigAttrSet * attrset, const char * basename)
     if(0) { /* Just here for the error cleanups*/
 ex_read_file:
         attrset->dirty = 0;
-        free(data);
-ex_data:
-        free(buffer);
 ex_init:
+        if(data)
+            free(data);
+        if(buffer)
+            free(buffer);
         fclose(fattr);
         return -1;
     }

--- a/src/bigfile.h
+++ b/src/bigfile.h
@@ -96,16 +96,16 @@ void big_attrset_set_dirty(BigAttrSet * attrset, int value);
 
 /** Initialise BigBlockPtr to the place in the BigBlock offset elements from the beginning of the block.
  * This allows you to write into the BigBlock at a position other than the beginning.
- * @param offset - Position to seek to in units of the size of the array element, eg, 8 bytes for an i8. 
+ * @param offset - Position to seek to in units of the size of the array element, eg, 8 bytes for an i8.
  *                 If offset < 0, seek to size + offset.
  *
  */
 int big_block_seek(BigBlock * bb, BigBlockPtr * ptr, ptrdiff_t offset); /* raises */
 int big_block_seek_rel(BigBlock * bb, BigBlockPtr * ptr, ptrdiff_t rel); /* raises */
 
-/** Detect for end of file 
+/** Detect for end of file
  *
- *  Returns non-zero is the ptr is at EOF 
+ *  Returns non-zero is the ptr is at EOF
  * */
 int big_block_eof(BigBlock * bb, BigBlockPtr * ptr);
 
@@ -117,9 +117,9 @@ int big_block_eof(BigBlock * bb, BigBlockPtr * ptr);
  */
 int big_block_read(BigBlock * bb, BigBlockPtr * ptr, BigArray * array); /* raises */
 
-/** Read from a block and create a BigArray 
+/** Read from a block and create a BigArray
  *  array->buf shall be freed with the C free() function.
- * 
+ *
  *  @param size - Read `size' rows. This will not fail if start + size < bb->size.
  *  @param start - Read from `start'
  *  @param array - an empty BigArray struct, that will be initialized by this function.
@@ -141,6 +141,10 @@ int big_block_read_simple(BigBlock * bb, ptrdiff_t start, ptrdiff_t size, BigArr
  * @param array - BigArray containing the data which should be written.
  * @returns 0 if successful. */
 int big_block_write(BigBlock * bb, BigBlockPtr * ptr, BigArray * array); /* raisees*/
+
+/* Internal function which allows setting the mode with which the file is opened.
+ * @param mode - should be either "r+" or "w"*/
+int _big_block_write_mode(BigBlock * bb, BigBlockPtr * ptr, BigArray * array, const char * mode);
 
 /** Set an attribute on a BigBlock: attributes are plaintext key-value pairs stored in a special file in the Block directory.
  * The value may be a (small) array.
@@ -175,11 +179,11 @@ BigAttr * big_block_list_attrs(BigBlock * block, size_t * count);
  * dtype: a subset of numpy's dtype descriptor.
  *
  * dtype[0]: endianness, '<' for LE and '>' BE. '=' is native and will be converted to LE or BE during IO.
- * dtype[1]: kind in char: 
+ * dtype[1]: kind in char:
  *
- *    'i' :int, 
- *    'f'  float, 
- *    'c'  complex, 
+ *    'i' :int,
+ *    'f'  float,
+ *    'c'  complex,
  *    'u'  unsigned int
  *    'b'  boolean / byte
  *    'a'  string bytes
@@ -230,7 +234,7 @@ int big_file_dtype_parse(const char * buffer, const char * dtype, void * data, c
  * The array iteration increases the last dimension first. Therefore, the most straight-forward way of creating a BigArray for big_block_write
  * and big_block_read is dims = {chunksize, nmemb}, strides = NULL.
  *
- * The strides representation is quite flexible: the array can be ordered in other ways. 
+ * The strides representation is quite flexible: the array can be ordered in other ways.
  * For example, with:
  *
  * struct {  double pos[3];  double vel[3]; } * P;

--- a/src/mp-mpiu.c
+++ b/src/mp-mpiu.c
@@ -6,429 +6,46 @@
 
 #include <mpi.h>
 #include "mp-mpiu.h"
-static void * default_mpiu_malloc_func(const char * name, size_t size, const char * file, const int line, void * userdata) { return malloc(size); }
-static void default_mpiu_free_func(void * ptr, const char * file, const int line, void * userdata) { free(ptr); }
 
-static void * verbose_mpiu_malloc_func(const char * name, size_t size, const char * file, const int line, void * userdata) {
-    MPI_Comm comm = (MPI_Comm) (intptr_t) userdata;
-    int rank;
-    MPI_Comm_rank(comm, &rank);
-    void * ptr = malloc(size);
-    fprintf(stderr, "MPIU_Malloc: T%04d %16p : %s size = %ld, %s:%d\n", rank, ptr, name, size, file, line);
-    return ptr;
-}
-
-static void verbose_mpiu_free_func(void * ptr, const char * file, const int line, void * userdata) {
-    MPI_Comm comm = (MPI_Comm) (intptr_t) userdata;
-    int rank;
-    MPI_Comm_rank(comm, &rank);
-    fprintf(stderr, "MPIU_Free: T%04d %16p : %s:%d\n", rank, ptr, file, line);
-    free(ptr);
-}
-
-static struct {
-    mpiu_malloc_func malloc_func;
-    mpiu_free_func free_func;
-    void * userdata;
-} _MPIUMem = {
-    default_mpiu_malloc_func,
-    default_mpiu_free_func,
-    NULL
-};
-
-void
-mpiu_set_malloc(mpiu_malloc_func malloc, mpiu_free_func free, void * userdata)
-{
-    _MPIUMem.malloc_func = malloc;
-    _MPIUMem.free_func = free;
-    _MPIUMem.userdata = userdata;
-}
-
-void
-MPIU_Set_verbose_malloc(MPI_Comm comm)
-{
-    mpiu_set_malloc(verbose_mpiu_malloc_func, verbose_mpiu_free_func, (void*) (intptr_t) comm);
-}
-
-void * mpiu_malloc(const char * name, size_t size, const char * file, const int line) {
-    return _MPIUMem.malloc_func(name, size, file, line, _MPIUMem.userdata);
-}
-
-void mpiu_free(void * ptr, const char * file, const int line) {
-    _MPIUMem.free_func(ptr, file, line, _MPIUMem.userdata);
-}
-
-/* The following two functions are taken from MP-Gadget. The hope
- * is that when the exchange is sparse posting requests is
- * faster than Alltoall on some implementations. */
-
-static int MPI_Alltoallv_sparse(void *sendbuf, int *sendcnts, int *sdispls,
-        MPI_Datatype sendtype, void *recvbuf, int *recvcnts,
-        int *rdispls, MPI_Datatype recvtype, MPI_Comm comm);
-
-int MPIU_Alltoallv(void *sendbuf, int *sendcnts, int *sdispls,
-        MPI_Datatype sendtype, void *recvbuf, int *recvcnts,
-        int *rdispls, MPI_Datatype recvtype, MPI_Comm comm,
-        enum MPIU_AlltoallvSparsePolicy policy
-)
-/*
- * sdispls, recvcnts rdispls can be NULL,
- *
- * if recvbuf is NULL, returns total number of item required to hold the
- * data.
- * */
-{
-    int ThisTask;
-    int NTask;
-    MPI_Comm_rank(comm, &ThisTask);
-    MPI_Comm_size(comm, &NTask);
-    int i;
-    int nn = 0;
-    int *a_sdispls=NULL, *a_recvcnts=NULL, *a_rdispls=NULL;
-    for(i = 0; i < NTask; i ++) {
-        if(sendcnts[i] > 0) {
-            nn ++;
-        }
-    }
-    if(recvcnts == NULL) {
-        a_recvcnts = (int *) malloc(sizeof(int) * NTask);
-        recvcnts = a_recvcnts;
-        MPI_Alltoall(sendcnts, 1, MPI_INT,
-                     recvcnts, 1, MPI_INT, comm);
-    }
-    if(recvbuf == NULL) {
-        int totalrecv = 0;
-        for(i = 0; i < NTask; i ++) {
-            totalrecv += recvcnts[i];
-        }
-        if(a_recvcnts)
-            free(a_recvcnts);
-        return totalrecv;
-    }
-    if(sdispls == NULL) {
-        a_sdispls = (int *) malloc(sizeof(int) * NTask);
-        sdispls = a_sdispls;
-        sdispls[0] = 0;
-        for (i = 1; i < NTask; i++) {
-            sdispls[i] = sdispls[i - 1] + sendcnts[i - 1];
-        }
-    }
-    if(rdispls == NULL) {
-        a_rdispls = (int *) malloc(sizeof(int) * NTask);
-        rdispls = a_rdispls;
-        rdispls[0] = 0;
-        for (i = 1; i < NTask; i++) {
-            rdispls[i] = rdispls[i - 1] + recvcnts[i - 1];
-        }
-    }
-
-    int dense;
-
-    if(policy == AUTO) {
-        dense = nn > 128;
-        MPI_Allreduce(MPI_IN_PLACE, &dense, 1, MPI_INT, MPI_SUM, comm);
-    }
-    if(policy == DISABLED) {
-        dense = 1;
-    }
-    if(policy == REQUIRED) {
-        dense = 0;
-    }
-
-    int ret;
-    if(dense != 0) {
-        ret = MPI_Alltoallv(sendbuf, sendcnts, sdispls,
-                    sendtype, recvbuf,
-                    recvcnts, rdispls, recvtype, comm);
-    } else {
-        ret = MPI_Alltoallv_sparse(sendbuf, sendcnts, sdispls,
-                    sendtype, recvbuf,
-                    recvcnts, rdispls, recvtype, comm);
-    }
-
-    if(a_rdispls)
-        free(a_rdispls);
-    if(a_sdispls)
-        free(a_sdispls);
-    if(a_recvcnts)
-        free(a_recvcnts);
-    return ret;
-}
-
-static int MPI_Alltoallv_sparse(void *sendbuf, int *sendcnts, int *sdispls,
-        MPI_Datatype sendtype, void *recvbuf, int *recvcnts,
-        int *rdispls, MPI_Datatype recvtype, MPI_Comm comm) {
-
-    int ThisTask;
-    int NTask;
-    MPI_Comm_rank(comm, &ThisTask);
-    MPI_Comm_size(comm, &NTask);
-    int PTask;
-    int ngrp;
-
-    for(PTask = 0; NTask > (1 << PTask); PTask++);
-
-    ptrdiff_t lb;
-    ptrdiff_t send_elsize;
-    ptrdiff_t recv_elsize;
-
-    MPI_Type_get_extent(sendtype, &lb, &send_elsize);
-    MPI_Type_get_extent(recvtype, &lb, &recv_elsize);
-
-#ifndef NO_ISEND_IRECV_IN_DOMAIN
-    int n_requests;
-    MPI_Request *requests = (MPI_Request *) malloc(NTask * 2 * sizeof(MPI_Request));
-    n_requests = 0;
-
-
-    for(ngrp = 0; ngrp < (1 << PTask); ngrp++)
-    {
-        int target = ThisTask ^ ngrp;
-
-        if(target >= NTask) continue;
-        if(recvcnts[target] == 0) continue;
-        MPI_Irecv(
-                ((char*) recvbuf) + recv_elsize * rdispls[target],
-                recvcnts[target],
-                recvtype, target, 101934, comm, &requests[n_requests++]);
-    }
-
-    MPI_Barrier(comm);
-    /* not really necessary, but this will guarantee that all receives are
-       posted before the sends, which helps the stability of MPI on
-       bluegene, and perhaps some mpich1-clusters */
-    /* Note 08/2016: Even on modern hardware this barrier leads to a slight speedup.
-     * Probably because it allows the code to hit a fast path transfer.*/
-
-    for(ngrp = 0; ngrp < (1 << PTask); ngrp++)
-    {
-        int target = ThisTask ^ ngrp;
-        if(target >= NTask) continue;
-        if(sendcnts[target] == 0) continue;
-        MPI_Isend(((char*) sendbuf) + send_elsize * sdispls[target],
-                sendcnts[target],
-                sendtype, target, 101934, comm, &requests[n_requests++]);
-    }
-
-    MPI_Waitall(n_requests, requests, MPI_STATUSES_IGNORE);
-    free(requests);
-#else
-    for(ngrp = 0; ngrp < (1 << PTask); ngrp++)
-    {
-        int target = ThisTask ^ ngrp;
-
-        if(target >= NTask) continue;
-        if(sendcnts[target] == 0 && recvcnts[target] == 0) continue;
-        MPI_Sendrecv(((char*)sendbuf) + send_elsize * sdispls[target],
-                sendcnts[target], sendtype,
-                target, 101934,
-                ((char*)recvbuf) + recv_elsize * rdispls[target],
-                recvcnts[target], recvtype,
-                target, 101934,
-                comm, MPI_STATUS_IGNORE);
-
-    }
-#endif
-    /* ensure the collective-ness */
-    MPI_Barrier(comm);
-
-    return 0;
-}
-
-/* Find the rank that has the value of MPI_MIN, or MPI_MAX.
- * If there is degeneracy, return the lower rank.
- * Avoids MPI_MINLOC and MPI_MAXLOC.
- * */
-int
-MPIU_GetLoc(const void * base, MPI_Datatype type, MPI_Op op, MPI_Comm comm)
-{
-    ptrdiff_t lb;
-    ptrdiff_t elsize;
-    MPI_Type_get_extent(type, &lb, &elsize);
-
-    void * tmp = malloc(elsize);
-    /* find the result of the reduction. */
-    MPI_Allreduce(base, tmp, 1, type, op, comm);
-
-    int ThisTask;
-    int NTask;
-    MPI_Comm_size(comm, &NTask);
-    MPI_Comm_rank(comm, &ThisTask);
-    int rank = NTask;
-    int ret = -1;
-    if (memcmp(base, tmp, elsize) == 0) {
-        rank = ThisTask;
-    }
-    /* find the rank that is the same as the reduction result */
-    /* avoid MPI_IN_PLACE, since if we are using this code, we have assumed we are using
-     * a crazy MPI impl...
-     * */
-    MPI_Allreduce(&rank, &ret, 1, MPI_INT, MPI_MIN, comm);
-    free(tmp);
-    return ret;
-}
-
-void *
-MPIU_Gather (MPI_Comm comm, int root, const void * sendbuffer, void * recvbuffer, int nsend, size_t elsize, int * totalnrecv)
-{
-    int NTask;
-    int ThisTask;
-
-    MPI_Comm_size(comm, &NTask);
-    MPI_Comm_rank(comm, &ThisTask);
-
-    MPI_Datatype dtype;
-    MPI_Type_contiguous(elsize, MPI_BYTE, &dtype);
-    MPI_Type_commit(&dtype);
-
-    int recvcount[NTask];
-    int rdispls[NTask + 1];
-    int i;
-    MPI_Gather(&nsend, 1, MPI_INT, recvcount, 1, MPI_INT, root, comm);
-
-    rdispls[0] = 0;
-    for(i = 1; i <= NTask; i ++) {
-        rdispls[i] = rdispls[i - 1] + recvcount[i - 1];
-    }
-
-    if(ThisTask == root) {
-        if(recvbuffer == NULL)
-            recvbuffer = MPIU_Malloc("recvbuffer", elsize, rdispls[NTask]);
-        if(totalnrecv)
-            *totalnrecv = rdispls[NTask];
-    } else {
-        if(totalnrecv)
-            *totalnrecv = 0;
-    }
-
-    MPI_Gatherv(sendbuffer, nsend, dtype, recvbuffer, recvcount, rdispls, dtype, root, comm);
-
-    MPI_Type_free(&dtype);
-
-    return recvbuffer;
-}
-
-void *
-MPIU_Scatter (MPI_Comm comm, int root, const void * sendbuffer, void * recvbuffer, int nrecv, size_t elsize, int * totalnsend)
-{
-    int NTask;
-    int ThisTask;
-    MPI_Comm_size(comm, &NTask);
-    MPI_Comm_rank(comm, &ThisTask);
-
-    MPI_Datatype dtype;
-    MPI_Type_contiguous(elsize, MPI_BYTE, &dtype);
-    MPI_Type_commit(&dtype);
-
-    int sendcount[NTask];
-    int sdispls[NTask + 1];
-    int i;
-
-    MPI_Gather(&nrecv, 1, MPI_INT, sendcount, 1, MPI_INT, root, comm);
-
-    sdispls[0] = 0;
-    for(i = 1; i <= NTask; i ++) {
-        sdispls[i] = sdispls[i - 1] + sendcount[i - 1];
-    }
-
-    if(recvbuffer == NULL)
-        recvbuffer = MPIU_Malloc("recvbuffer", elsize, nrecv);
-
-    if(ThisTask == root) {
-        if(totalnsend)
-            *totalnsend = sdispls[NTask];
-    } else {
-        if(totalnsend)
-            *totalnsend = 0;
-    }
-    MPI_Scatterv(sendbuffer, sendcount, sdispls, dtype, recvbuffer, nrecv, dtype, root, comm);
-
-    MPI_Type_free(&dtype);
-
-    return recvbuffer;
-}
-
-int
-_MPIU_Segmenter_assign_colors(size_t glocalsize, size_t * sizes, size_t * sizes2, int * ncolor, MPI_Comm comm)
+static int
+_MPIU_Segmenter_assign_segment_numbers(size_t glocalsize, size_t * sizes, int * nsegment, MPI_Comm comm)
 {
     int NTask;
     int ThisTask;
     MPI_Comm_rank(comm, &ThisTask);
     MPI_Comm_size(comm, &NTask);
-
-    if (sizes2 == NULL) {
-        sizes2 = sizes;
-    }
 
     int i;
-    int mycolor = -1;
+    /* no data for color of -1; exclude them later with special cases */
+    int mysegment = -1;
     size_t current_size = 0;
-    size_t current_sizes2 = 0;
-    int current_color = 0;
-    int lastcolor = 0;
+    int current_segment = 0;
     for(i = 0; i < NTask; i ++) {
         current_size += sizes[i];
-        current_sizes2 += sizes2[i];
-
-        lastcolor = current_color;
-
-        if(i == ThisTask) {
-            mycolor = lastcolor;
+        /* Assign a colour to this task,
+         * maximally equal to the number of
+         * tasks with data before this one.*/
+        if(i == ThisTask && sizes[i] > 0) {
+            mysegment = current_segment;
         }
 
-        if(current_size > glocalsize || current_sizes2 > glocalsize) {
+        /* Start a new segment if we have too much data
+         * for this one and more tasks to assign*/
+        if(current_size > glocalsize && i < NTask -1) {
             current_size = 0;
-            current_sizes2 = 0;
-            current_color ++;
+            current_segment ++;
         }
     }
-    /* no data for color of -1; exclude them later with special cases */
-    if(sizes[ThisTask] == 0 && sizes2[ThisTask] == 0) {
-        mycolor = -1;
-    }
-
-    *ncolor = lastcolor + 1;
-    return mycolor;
-}
-
-size_t
-MPIU_Segmenter_collect_sizes(size_t localsize, size_t * sizes, size_t * myoffset, MPI_Comm comm)
-{
-
-    int ThisTask, NTask;
-
-    MPI_Comm_size(comm, &NTask);
-    MPI_Comm_rank(comm, &ThisTask);
-
-    size_t totalsize;
-
-    sizes[ThisTask] = localsize;
-
-    MPI_Datatype MPI_PTRDIFFT;
-
-    if(sizeof(ptrdiff_t) == sizeof(long)) {
-        MPI_PTRDIFFT = MPI_LONG;
-    } else if(sizeof(ptrdiff_t) == sizeof(int)) {
-        MPI_PTRDIFFT = MPI_INT;
-    } else { abort(); }
-
-    MPI_Allreduce(&sizes[ThisTask], &totalsize, 1, MPI_PTRDIFFT, MPI_SUM, comm);
-    MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, sizes, 1, MPI_PTRDIFFT, comm);
-
-    int i;
-    *myoffset = 0;
-    for(i = 0; i < ThisTask; i ++) {
-        (*myoffset) += sizes[i];
-    }
-
-    return totalsize;
+    *nsegment = current_segment + 1;
+    return mysegment;
 }
 
 void
 MPIU_Segmenter_init(MPIU_Segmenter * segmenter,
                size_t * sizes,
-               size_t * sizes2,
-               size_t avgsegsize,
+               size_t totalsize,
+               size_t maxsegsize,
+               size_t minsegsize,
                int Ngroup,
                MPI_Comm comm)
 {
@@ -437,41 +54,55 @@ MPIU_Segmenter_init(MPIU_Segmenter * segmenter,
     MPI_Comm_size(comm, &NTask);
     MPI_Comm_rank(comm, &ThisTask);
 
-    segmenter->ThisSegment = _MPIU_Segmenter_assign_colors(avgsegsize, sizes, sizes2, &segmenter->Nsegments, comm);
+    if(Ngroup <= 0 || Ngroup > NTask)
+        Ngroup = NTask;
+
+    /* try to create as many segments as number of groups (thus one segment per group) */
+    size_t avgsegsize = totalsize / Ngroup;
+
+    /* For small segments it is more efficient to gather all the data to a single rank in the group and write it at once*/
+    if(avgsegsize < minsegsize)
+        avgsegsize = minsegsize;
+
+    /* no segment shall exceed the memory bound set by maxsegsize, since it will be collected to a single rank */
+    if(avgsegsize > maxsegsize)
+        avgsegsize = maxsegsize;
+
+    /* If avgsegsize == 0, this assigns a segment number in order to every rank which has non-zero data.
+       If avgsegsize > 0, a new segment number is assigned every time a rank exceeds avgsegsize. */
+    segmenter->ThisSegment = _MPIU_Segmenter_assign_segment_numbers(avgsegsize, sizes, &segmenter->Nsegments, comm);
 
     if(segmenter->ThisSegment >= 0) {
         /* assign segments to groups.
          * if Nsegments < Ngroup, some groups will have no segments, and thus no ranks belong to them. */
         segmenter->GroupID = ((size_t) segmenter->ThisSegment) * Ngroup / segmenter->Nsegments;
     } else {
+        /* Ranks with no data end up here and in a special group with nothing to do*/
         segmenter->GroupID = Ngroup + 1;
         segmenter->ThisSegment = NTask + 1;
     }
 
     segmenter->Ngroup = Ngroup;
 
+    /* Split the communicator into groups of segments*/
     MPI_Comm_split(comm, segmenter->GroupID, ThisTask, &segmenter->Group);
 
+    /* Find the minimum and maximum rank of this segment in this group*/
     MPI_Allreduce(&segmenter->ThisSegment, &segmenter->segment_start, 1, MPI_INT, MPI_MIN, segmenter->Group);
     MPI_Allreduce(&segmenter->ThisSegment, &segmenter->segment_end, 1, MPI_INT, MPI_MAX, segmenter->Group);
 
     segmenter->segment_end ++;
 
-    int rank;
-
-    MPI_Comm_rank(segmenter->Group, &rank);
-
-    /* rank with most data in a group is the leader of the group. */
-    segmenter->group_leader_rank = MPIU_GetLoc(&sizes[ThisTask], MPI_LONG, MPI_MAX, segmenter->Group);
-
-    segmenter->is_group_leader = rank == segmenter->group_leader_rank;
-
-    MPI_Comm_split(comm, (rank == segmenter->group_leader_rank)? 0 : 1, ThisTask, &segmenter->Leaders);
-
     MPI_Comm_split(segmenter->Group, segmenter->ThisSegment, ThisTask, &segmenter->Segment);
 
-    /* rank with least data in a segment is the leader of the segment. */
-    segmenter->segment_leader_rank = MPIU_GetLoc(&sizes[ThisTask], MPI_LONG, MPI_MIN, segmenter->Segment);
+    /* rank with least data in a segment is the leader of the segment.
+     * Use the rank within Segment (not the global rank) as the identifier. */
+    int segment_rank;
+    MPI_Comm_rank(segmenter->Segment, &segment_rank);
+    struct { long val; int rank; } local = { (long)sizes[ThisTask], segment_rank };
+    struct { long val; int rank; } result;
+    MPI_Allreduce(&local, &result, 1, MPI_LONG_INT, MPI_MINLOC, segmenter->Segment);
+    segmenter->segment_leader_rank = result.rank;
 }
 
 void
@@ -479,6 +110,5 @@ MPIU_Segmenter_destroy(MPIU_Segmenter * segmenter)
 {
     MPI_Comm_free(&segmenter->Segment);
     MPI_Comm_free(&segmenter->Group);
-    MPI_Comm_free(&segmenter->Leaders);
 }
 

--- a/src/mp-mpiu.h
+++ b/src/mp-mpiu.h
@@ -1,58 +1,6 @@
 #ifndef _MPIU_H_
 #define _MPIU_H_
 
-typedef void * (*mpiu_malloc_func)(const char * name, size_t size, const char * file, const int line, void * userdata);
-typedef void (*mpiu_free_func)(void * ptr, const char * file, const int line, void * userdata);
-
-void * mpiu_malloc(const char * name, size_t size, const char * file, const int line);
-void mpiu_free(void * ptr, const char * file, const int line);
-
-void mpiu_set_malloc(mpiu_malloc_func malloc, mpiu_free_func free, void * userdata);
-void MPIU_Set_verbose_malloc(MPI_Comm comm);
-
-/*
- * Set the MPIU memory allocator. MPIU uses the allocator to provided a hook for tracking allocations of significance.
- * */
-#define MPIU_SetMalloc mpiu_set_malloc
-#define MPIU_MallocT(name, type, nmemb) MPIU_Malloc(name, sizeof(type), nmemb, __FILE__, __LINE__)
-#define MPIU_Malloc(name, elsize, nmemb) mpiu_malloc(name, ((size_t)(elsize)) * nmemb, __FILE__, __LINE__)
-#define MPIU_Free(ptr) mpiu_free(ptr, __FILE__, __LINE__)
-
-/*
- * MPIU_Alltoallv:
- * a Alltoallv can automatically switch to a sparse implementation
- */
-enum MPIU_AlltoallvSparsePolicy {
-    AUTO = 0,
-    DISABLED = 1,
-    REQUIRED = 2
-};
-
-int MPIU_Alltoallv(void *sendbuf, int *sendcnts, int *sdispls,
-        MPI_Datatype sendtype, void *recvbuf, int *recvcnts,
-        int *rdispls, MPI_Datatype recvtype, MPI_Comm comm,
-        enum MPIU_AlltoallvSparsePolicy policy);
-
-/*
- * Returns the rank that contains the first result matching the MPI_Op.
- * op can be MPI_MIN or MPI_MAX. This function works around potentially buggy
- * MPI_MINLOC and MPI_MAXLOC implemenations.
- * */
-int
-MPIU_GetLoc(const void * base, MPI_Datatype type, MPI_Op op, MPI_Comm comm);
-
-/*
- * Gathers from all ranks to root. if recvbuffer is NULL, allocate new memory with MPIU_Malloc.
- */
-void *
-MPIU_Gather (MPI_Comm comm, int root, const void * sendbuffer, void * recvbuffer, int nsend, size_t elsize, int * totalnrecv);
-
-/*
- * Scatter from root to all ranks. if recvbuffer is NULL, allocate new memory with MPIU_Malloc.
- */
-void *
-MPIU_Scatter (MPI_Comm comm, int root, const void * sendbuffer, void * recvbuffer, int nrecv, size_t elsize, int * totalnsend);
-
 /* Segment a MPI Comm into 'groups', such that distributed data in each group is roughly even.
  * NOTE: this API needs some revision to incorporate some of the downstream behaviors. Currently
  * the internal data structure is directly accessed by downstream.
@@ -64,20 +12,13 @@ typedef struct MPIU_Segmenter {
     int GroupID; /* ID of the group of this rank */
     int ThisSegment; /* SegmentID of the local data chunk on this rank*/
 
-    size_t totalsize;
     int segment_start; /* segments responsible in this group */
     int segment_end;
 
-    int is_group_leader;
-    int group_leader_rank;
     int segment_leader_rank;
     MPI_Comm Group;  /* communicator for all ranks in the group */
-    MPI_Comm Leaders; /* communicator for all ranks by leaders vs nonleaders */
     MPI_Comm Segment; /* communicator for all ranks in this segment */
 } MPIU_Segmenter;
-
-size_t
-MPIU_Segmenter_collect_sizes(size_t localsize, size_t * sizes, size_t * myoffset, MPI_Comm comm);
 
 /* MPIU_segmenter_init: Create a Segmenter.
  * the total number of items according to both sizes and sizes2 will not
@@ -86,8 +27,9 @@ MPIU_Segmenter_collect_sizes(size_t localsize, size_t * sizes, size_t * myoffset
 void
 MPIU_Segmenter_init(MPIU_Segmenter * segmenter,
                size_t * sizes,   /* IN: size per rank, used to bound the number of ranks in a group. */
-               size_t * sizes2,  /* IN: if given, secondary size used to bound the number of ranks in a group. */
-               size_t expected_segsize, /* desired size per segment */
+               size_t totalsize, /* Total size of data to segment into groups. */
+               size_t maxsegsize, /* Maximum desired segment size. Can still be exceeded if a single rank has more data than this.*/
+               size_t minsegsize, /* Minimum desired segment size. Segments smaller than this are gathered to one rank*/
                int Ngroup,  /* number of groups to form. */
                MPI_Comm comm);
 void


### PR DESCRIPTION
Update bigfile to include the new create_and_write API and use it to write snapshots where each file is written to only by one rank at a time.

This fixes the "snapshot full of zeros" issue on AArch64.

Also clean up the I/O options in petaio.