### PR TITLE
Cleanersyncpoint

### DIFF
--- a/libgadget/tests/test_timebinmgr.cpp
+++ b/libgadget/tests/test_timebinmgr.cpp
@@ -81,8 +81,30 @@ BOOST_AUTO_TEST_CASE(test_dloga)
 
     TimeBinMgr tbm(NULL, TIMEIC, TIMEMAX, 0.0, 0);
 
+    /* a=0.55 sits in the (non-uniformly spaced) segment [0.2, 0.8].*/
     inttime_t Ti_Current = tbm.ti_from_loga(log(0.55));
-    /* unsigned int dti_from_dloga(double loga); */
+    double loga0 = tbm.loga_from_ti(Ti_Current);
+
+    /* unsigned int dti_from_dloga(double dloga, inttime_t Ti_Current); */
+    /* dti_from_dloga must agree with the difference of the two endpoints
+     * computed by ti_from_loga. This is the spec, and exercises the bit-trick
+     * segment arithmetic for both the in-segment and segment-crossing cases.*/
+    /* Stay within the current segment.*/
+    double dloga_in = (logouts[2]-logouts[1])/4;
+    BOOST_TEST(tbm.dti_from_dloga(dloga_in, Ti_Current) ==
+               tbm.ti_from_loga(loga0 + dloga_in) - tbm.ti_from_loga(loga0));
+    /* The current segment spans a full TIMEBASE in ti, so a dloga of a
+     * quarter of the segment width is a quarter of TIMEBASE. This would be
+     * wrong by the ratio of neighbouring segment widths if the wrong segment
+     * were used for the conversion.*/
+    inttime_t dti_in = tbm.dti_from_dloga(dloga_in, Ti_Current);
+    BOOST_TEST(dti_in <= TIMEBASE/4 + 2);
+    BOOST_TEST(dti_in >= TIMEBASE/4 - 2);
+    /* Cross from segment [0.2,0.8] into the next, narrower segment [0.8,1.0].*/
+    double dloga_cross = (logouts[2]-logouts[1])/2 + (logouts[3]-logouts[2])/4;
+    BOOST_TEST(tbm.dti_from_dloga(dloga_cross, Ti_Current) ==
+               tbm.ti_from_loga(loga0 + dloga_cross) - tbm.ti_from_loga(loga0));
+
     /* double dloga_from_dti(unsigned int ti); */
 
     /*Get dloga from a timebin*/

--- a/libgadget/tests/test_timebinmgr.cpp
+++ b/libgadget/tests/test_timebinmgr.cpp
@@ -47,14 +47,11 @@ BOOST_AUTO_TEST_CASE(test_conversions)
     BOOST_TEST(tbm.loga_from_ti(tbm.ti_from_loga(log(0.1))) == log(0.1), tt::tolerance(1e-6));
 
     /*! this function returns the next output time after ti_curr.*/
-    BOOST_TEST(tbm.find_next_sync_point(0)->ti == TIMEBASE);
-    BOOST_TEST(tbm.find_next_sync_point(TIMEBASE)->ti == 2 * TIMEBASE);
-    BOOST_TEST(tbm.find_next_sync_point(TIMEBASE-1)->ti == TIMEBASE);
-    BOOST_TEST(tbm.find_next_sync_point(TIMEBASE+1)->ti == 2*TIMEBASE);
-    BOOST_TEST(tbm.find_next_sync_point(4 * TIMEBASE) == nullptr);
+    BOOST_TEST(tbm.find_next_ti_sync(0) == TIMEBASE);
+    BOOST_TEST(tbm.find_next_ti_sync(TIMEBASE) == 2 * TIMEBASE);
+    BOOST_TEST(tbm.find_next_ti_sync(TIMEBASE-1) == TIMEBASE);
+    BOOST_TEST(tbm.find_next_ti_sync(TIMEBASE+1) == 2*TIMEBASE);
 
-    BOOST_TEST(tbm.find_current_sync_point(0)->ti == 0);
-    BOOST_TEST(tbm.find_current_sync_point(TIMEBASE)->ti == TIMEBASE);
     BOOST_TEST(tbm.find_current_sync_point(-1)  == nullptr);
     BOOST_TEST(tbm.find_current_sync_point(TIMEBASE-1) == nullptr);
 

--- a/libgadget/tests/test_timebinmgr.cpp
+++ b/libgadget/tests/test_timebinmgr.cpp
@@ -72,6 +72,34 @@ BOOST_AUTO_TEST_CASE(test_skip_first)
     BOOST_TEST(tbm2.find_current_sync_point(0)->write_snapshot == 1);
 }
 
+/* find_current_sync_point returns the sync point exactly at ti, or nullptr.
+ * The four outputs {0.1, 0.2, 0.8, 1.0} land on ti = 0, TIMEBASE, 2*TIMEBASE,
+ * 3*TIMEBASE. We check both that the right point is returned (by its loga, not
+ * just non-null) and that every off-sync ti gives nullptr.*/
+BOOST_AUTO_TEST_CASE(test_find_current_sync_point)
+{
+    setup();
+    TimeBinMgr tbm(NULL, TIMEIC, TIMEMAX, 0.0, false);
+
+    /* Each exact sync point returns the correctly-indexed entry.*/
+    BOOST_TEST(tbm.find_current_sync_point(0)->loga == logouts[0]);
+    BOOST_TEST(tbm.find_current_sync_point(TIMEBASE)->loga == logouts[1]);
+    BOOST_TEST(tbm.find_current_sync_point(2 * TIMEBASE)->loga == logouts[2]);
+    BOOST_TEST(tbm.find_current_sync_point(3 * TIMEBASE)->loga == logouts[3]);
+
+    /* ti that is not exactly on a sync point returns nullptr: negative,
+     * between sync points, and adjacent to a sync point on either side.*/
+    BOOST_TEST(tbm.find_current_sync_point(-1) == nullptr);
+    BOOST_TEST(tbm.find_current_sync_point(1) == nullptr);
+    BOOST_TEST(tbm.find_current_sync_point(TIMEBASE - 1) == nullptr);
+    BOOST_TEST(tbm.find_current_sync_point(TIMEBASE + 1) == nullptr);
+    BOOST_TEST(tbm.find_current_sync_point(TIMEBASE + TIMEBASE / 2) == nullptr);
+
+    /* ti at or beyond the last sync point (index 3) has no entry.*/
+    BOOST_TEST(tbm.find_current_sync_point(4 * TIMEBASE) == nullptr);
+    BOOST_TEST(tbm.find_current_sync_point(100 * TIMEBASE) == nullptr);
+}
+
 BOOST_AUTO_TEST_CASE(test_dloga)
 {
     setup();

--- a/libgadget/timebinmgr.cpp
+++ b/libgadget/timebinmgr.cpp
@@ -74,6 +74,7 @@ TimeBinMgr::TimeBinMgr(Cosmology * CP, double TimeIC, double TimeMax, double no_
 {
     this->CP = CP;
 
+    std::vector<SyncPoint> SyncPoints;
     /* Set up first entry*/
     SyncPoint tmpsync;
     tmpsync.loga = log(TimeIC);
@@ -195,10 +196,13 @@ TimeBinMgr::TimeBinMgr(Cosmology * CP, double TimeIC, double TimeMax, double no_
         SyncPoints[j].plane_snapnum = i;
     }
 
+    // This avoids the memory access overhead of std::vector and avoids copying.
+    this->SyncPoints = std::make_unique<SyncPoint[]>(SyncPoints.size());
+    this->NSyncPoints = SyncPoints.size();
     //message(1,"NSyncPoints = %ld, OutputListLength = %ld , timemax = %.3f\n",NSyncPoints,Sync.OutputListLength,TimeMax);
-    /*for(i = 0; i < NSyncPoints; i++) {
-        message(1,"Out: %g %ld\n", exp(SyncPoints[i].loga), SyncPoints[i].ti);
-    }*/
+    for(int i = 0; i < this->NSyncPoints; i++) {
+        this->SyncPoints[i] = SyncPoints[i];
+    }
 }
 
 /* Function to compute comoving distance using the adaptive integrator */

--- a/libgadget/timebinmgr.cpp
+++ b/libgadget/timebinmgr.cpp
@@ -1,18 +1,11 @@
 #include <mpi.h>
 #include <math.h>
-#include <string.h>
-#include <stdlib.h>
 #include <vector>
-#include <sstream>
 #include <boost/math/quadrature/gauss_kronrod.hpp>
 
 #include "timebinmgr.h"
 #include "utils/endrun.h"
-#include "utils/mymalloc.h"
-
 #include "cosmology.h"
-
-#define MAXTIMES 1024
 
 static struct sync_params
 {
@@ -80,52 +73,37 @@ void set_sync_params_test(int OutputListLength, double * OutputListTimes)
 TimeBinMgr::TimeBinMgr(Cosmology * CP, double TimeIC, double TimeMax, double no_snapshot_until_time, bool SnapshotWithFOF)
 {
     this->CP = CP;
-    int64_t NSyncPointsAlloc = Sync.OutputListTimes.size() + Sync.PlaneOutputListTimes.size() + 2;
 
-    /* Excursion set sync points ensure that the reionization excursion set model is run frequently*/
-    const double ExcursionSet_delta_a = 0.0001;
-    const double a_end = 1/(1+Sync.ExcursionSetZStop) < TimeMax ? 1/(1+Sync.ExcursionSetZStop) : TimeMax;
-
-    if(Sync.ExcursionSetReionOn) {
-        double uv_a = 1/(1+Sync.ExcursionSetZStart) > TimeIC ? 1/(1+Sync.ExcursionSetZStart) : TimeIC;
-        while (uv_a <= a_end) {
-            NSyncPointsAlloc++;
-            double lbt = time_to_present(uv_a,CP);
-            double delta_lbt = 0.0;
-            while ((delta_lbt <= Sync.UVBGTimestep) && (uv_a <= TimeMax)) {
-                uv_a += ExcursionSet_delta_a;
-                delta_lbt = lbt - time_to_present(uv_a,CP);
-            }
-        }
-    }
-    //z=20 to z=4 is ~150 syncpoints at 10 Myr spaces
-    SyncPoints = mymalloc("SyncPoints", SyncPoint, NSyncPointsAlloc);
-
-    /* Set up first and last entry to SyncPoints; TODO we can insert many more! */
-    //NOTE(jdavies): these first syncpoints need to be in order
-
-    SyncPoints[0].a = TimeIC;
-    SyncPoints[0].loga = log(TimeIC);
-    SyncPoints[0].write_snapshot = false; /* by default no output here. */
-    SyncPoints[0].write_fof = false;
-    SyncPoints[0].calc_uvbg = false;
-    SyncPoints[0].write_plane = false;
-    SyncPoints[0].plane_snapnum = -1;
-    NSyncPoints = 1;
+    /* Set up first entry*/
+    SyncPoint tmpsync;
+    tmpsync.a = TimeIC;
+    tmpsync.loga = log(TimeIC);
+    tmpsync.write_snapshot = false; /* by default no output here. */
+    tmpsync.write_fof = false;
+    tmpsync.calc_uvbg = false;
+    tmpsync.write_plane = false;
+    tmpsync.plane_snapnum = -1;
+    tmpsync.ti = 0;
+    SyncPoints.push_back(tmpsync);
 
     // set up UVBG syncpoints at given intervals
     if(Sync.ExcursionSetReionOn) {
+        /* Excursion set sync points ensure that the reionization excursion set model is run frequently*/
+        const double ExcursionSet_delta_a = 0.0001;
+        const double a_end = 1/(1+Sync.ExcursionSetZStop) < TimeMax ? 1/(1+Sync.ExcursionSetZStop) : TimeMax;
         double uv_a = 1/(1+Sync.ExcursionSetZStart) > TimeIC ? 1/(1+Sync.ExcursionSetZStart) : TimeIC;
         while (uv_a <= a_end) {
-            SyncPoints[NSyncPoints].a = uv_a;
-            SyncPoints[NSyncPoints].loga = log(uv_a);
-            SyncPoints[NSyncPoints].write_snapshot = 0;
-            SyncPoints[NSyncPoints].write_fof = 0;
-            SyncPoints[NSyncPoints].calc_uvbg = 1;
-            NSyncPoints++;
-            if(NSyncPoints > NSyncPointsAlloc)
-                endrun(1, "Tried to generate %ld syncpoints, %ld allocated\n", NSyncPoints, NSyncPointsAlloc);
-            //message(0,"added UVBG syncpoint at a = %.3f z = %.3f, Nsync = %ld\n",uv_a,1/uv_a - 1,NSyncPoints);
+            SyncPoint tmpsync;
+            tmpsync.a = uv_a;
+            tmpsync.loga = log(uv_a);
+            tmpsync.write_snapshot = false; /* by default no output here. */
+            tmpsync.write_fof = false;
+            tmpsync.calc_uvbg = true;
+            tmpsync.write_plane = false;
+            tmpsync.plane_snapnum = -1;
+            tmpsync.ti = 0;
+            SyncPoints.push_back(tmpsync);
+            //message(0,"added UVBG syncpoint at a = %.3f z = %.3f, Nsync = %ld\n",uv_a,1/uv_a - 1,SyncPoints.size());
             // TODO(smutch): OK - this is ridiculous (sorry!), but I just wanted to quickly hack something...
             // TODO(jdavies): fix low-z where delta_a > 10Myr
             double lbt = time_to_present(uv_a,CP);
@@ -136,25 +114,25 @@ TimeBinMgr::TimeBinMgr(Cosmology * CP, double TimeIC, double TimeMax, double no_
                 //message(0,"trying UVBG syncpoint at a = %.3e, z = %.3e, delta_lbt = %.3e\n",uv_a,1/uv_a - 1,delta_lbt);
             }
         }
-        message(0,"Added %ld Syncpoints for the excursion Set\n",NSyncPoints-1);
+        message(0,"Added %lu Syncpoints for the excursion Set\n",SyncPoints.size()-1);
     }
 
-    SyncPoints[NSyncPoints].a = TimeMax;
-    SyncPoints[NSyncPoints].loga = log(TimeMax);
-    SyncPoints[NSyncPoints].write_snapshot = true;
-    SyncPoints[NSyncPoints].calc_uvbg = false;
-    SyncPoints[NSyncPoints].write_fof = true;
-    SyncPoints[NSyncPoints].write_plane = false;
-    SyncPoints[NSyncPoints].plane_snapnum = -1;
-    NSyncPoints++;
+    tmpsync.a = TimeMax;
+    tmpsync.loga = log(TimeMax);
+    tmpsync.write_snapshot = true; /* by default no output here. */
+    tmpsync.write_fof = true;
+    tmpsync.calc_uvbg = false;
+    tmpsync.write_plane = false;
+    tmpsync.plane_snapnum = -1;
+    tmpsync.ti = 0;
+    SyncPoints.push_back(tmpsync);
 
     /* we do an insertion sort here. A heap is faster but who cares the speed for this? */
     for(size_t i = 0; i < Sync.OutputListTimes.size(); i ++) {
         // print outputlisttime and index
         // message(0, "outIdx: %d, outtime: %g, planeoutIdx: %d, planeouttime: %g.\n", outIdx, Sync.OutputListTimes[outIdx], planeoutIdx, Sync.PlaneOutputListTimes[planeoutIdx]);
-        int64_t j = 0;
+        size_t j = 0;
         double a = Sync.OutputListTimes[i];
-        double loga = log(a);
 
         if(a < TimeIC || a > TimeMax) {
             /*If the user inputs syncpoints outside the scope of the simulation, it can mess
@@ -163,34 +141,36 @@ TimeBinMgr::TimeBinMgr(Cosmology * CP, double TimeIC, double TimeMax, double no_
             continue;
         }
 
-        for(j = 0; j < NSyncPoints; j ++) {
+        for(j = 0; j < SyncPoints.size(); j ++) {
             if(a <= SyncPoints[j].a) {
                 break;
             }
         }
         /* found, so loga >= SyncPoints[j].loga */
-        if(a == SyncPoints[j].a) {
-            /* requesting output on an existing entry, e.g. TimeInit or duplicated entry */
-        } else {
+        if(a != SyncPoints[j].a) {
             /* insert the item; */
-            memmove(&SyncPoints[j + 1], &SyncPoints[j], sizeof(SyncPoints[0]) * (NSyncPoints - j));
-            memset(&SyncPoints[j], 0, sizeof(SyncPoints[0]));
-            SyncPoints[j].a = a;
-            SyncPoints[j].loga = loga;
-            NSyncPoints ++;
-            //message(0,"added outlist syncpoint at a = %.3f, j = %d, Ns = %ld\n",a,j,NSyncPoints);
+            tmpsync.a = a;
+            tmpsync.loga = log(a);
+            tmpsync.write_snapshot = false; /* by default no output here. */
+            tmpsync.write_fof = false;
+            tmpsync.calc_uvbg = false;
+            tmpsync.write_plane = false;
+            tmpsync.plane_snapnum = -1;
+            tmpsync.ti = 0;
+            SyncPoints.insert(SyncPoints.begin() + j, tmpsync);
+            //message(0,"added outlist syncpoint at a = %.3f, j = %ld, Ns = %ld\n",a,j,SyncPoints.size());
         }
         if(SyncPoints[j].a > no_snapshot_until_time) {
-            SyncPoints[j].write_snapshot = 1;
+            SyncPoints[j].write_snapshot = true;
             if(SnapshotWithFOF)
-                SyncPoints[j].write_fof = 1;
+                SyncPoints[j].write_fof = true;
         }
         SyncPoints[j].plane_snapnum = -1;
     }
 
     /* Now insert the plane outputs*/
     for(size_t i = 0; i < Sync.PlaneOutputListTimes.size(); i ++) {
-        int64_t j = 0;
+        size_t j = 0;
         double a = Sync.PlaneOutputListTimes[i];
         double loga = log(a);
         if(a < TimeIC || a > TimeMax) {
@@ -200,7 +180,7 @@ TimeBinMgr::TimeBinMgr(Cosmology * CP, double TimeIC, double TimeMax, double no_
             continue;
         }
 
-        for(j = 0; j < NSyncPoints; j ++) {
+        for(j = 0; j < SyncPoints.size(); j ++) {
             if(a <= SyncPoints[j].a) {
                 break;
             }
@@ -209,22 +189,24 @@ TimeBinMgr::TimeBinMgr(Cosmology * CP, double TimeIC, double TimeMax, double no_
         // to avoid setting sync points too close to each other (which can cause bad timestep errors)
         if(fabs(loga - SyncPoints[j].loga) > 1e-4) {
             /* insert a blank item with no snapshot output. */
-            memmove(&SyncPoints[j + 1], &SyncPoints[j], sizeof(SyncPoints[0]) * (NSyncPoints - j));
-            memset(&SyncPoints[j], 0, sizeof(SyncPoints[0]));
-            SyncPoints[j].a = a;
-            SyncPoints[j].loga = loga;
-            NSyncPoints ++;
-            //message(0,"added outlist syncpoint at a = %.3f, j = %d, Ns = %ld\n",a,j,NSyncPoints);
+            tmpsync.a = a;
+            tmpsync.loga = loga;
+            tmpsync.write_snapshot = false; /* by default no output here. */
+            tmpsync.write_fof = false;
+            tmpsync.calc_uvbg = false;
+            tmpsync.write_plane = false;
+            tmpsync.plane_snapnum = -1;
+            tmpsync.ti = 0;
+            SyncPoints.insert(SyncPoints.begin() + j, tmpsync);
+            //message(0,"added outlist syncpoint at a = %.3f, j = %ld, Ns = %ld\n",a,j,SyncPoints.size());
         }
         SyncPoints[j].write_plane = 1;
         SyncPoints[j].plane_snapnum = i;
     }
 
-    for(int i = 0; i < NSyncPoints; i++) {
+    for(size_t i = 0; i < SyncPoints.size(); i++) {
         SyncPoints[i].ti = (i * 1L) << (TIMEBINS);
     }
-    if(NSyncPoints > NSyncPointsAlloc)
-        endrun(1, "Tried to generate %ld syncpoints, %ld allocated\n", NSyncPoints, NSyncPointsAlloc);
 
     //message(1,"NSyncPoints = %ld, OutputListLength = %ld , timemax = %.3f\n",NSyncPoints,Sync.OutputListLength,TimeMax);
     /*for(i = 0; i < NSyncPoints; i++) {

--- a/libgadget/timebinmgr.cpp
+++ b/libgadget/timebinmgr.cpp
@@ -76,14 +76,12 @@ TimeBinMgr::TimeBinMgr(Cosmology * CP, double TimeIC, double TimeMax, double no_
 
     /* Set up first entry*/
     SyncPoint tmpsync;
-    tmpsync.a = TimeIC;
     tmpsync.loga = log(TimeIC);
     tmpsync.write_snapshot = false; /* by default no output here. */
     tmpsync.write_fof = false;
     tmpsync.calc_uvbg = false;
     tmpsync.write_plane = false;
     tmpsync.plane_snapnum = -1;
-    tmpsync.ti = 0;
     SyncPoints.push_back(tmpsync);
 
     // set up UVBG syncpoints at given intervals
@@ -94,14 +92,12 @@ TimeBinMgr::TimeBinMgr(Cosmology * CP, double TimeIC, double TimeMax, double no_
         double uv_a = 1/(1+Sync.ExcursionSetZStart) > TimeIC ? 1/(1+Sync.ExcursionSetZStart) : TimeIC;
         while (uv_a <= a_end) {
             SyncPoint tmpsync;
-            tmpsync.a = uv_a;
             tmpsync.loga = log(uv_a);
             tmpsync.write_snapshot = false; /* by default no output here. */
             tmpsync.write_fof = false;
             tmpsync.calc_uvbg = true;
             tmpsync.write_plane = false;
             tmpsync.plane_snapnum = -1;
-            tmpsync.ti = 0;
             SyncPoints.push_back(tmpsync);
             //message(0,"added UVBG syncpoint at a = %.3f z = %.3f, Nsync = %ld\n",uv_a,1/uv_a - 1,SyncPoints.size());
             // TODO(smutch): OK - this is ridiculous (sorry!), but I just wanted to quickly hack something...
@@ -117,14 +113,12 @@ TimeBinMgr::TimeBinMgr(Cosmology * CP, double TimeIC, double TimeMax, double no_
         message(0,"Added %lu Syncpoints for the excursion Set\n",SyncPoints.size()-1);
     }
 
-    tmpsync.a = TimeMax;
     tmpsync.loga = log(TimeMax);
     tmpsync.write_snapshot = true; /* by default no output here. */
     tmpsync.write_fof = true;
     tmpsync.calc_uvbg = false;
     tmpsync.write_plane = false;
     tmpsync.plane_snapnum = -1;
-    tmpsync.ti = 0;
     SyncPoints.push_back(tmpsync);
 
     /* we do an insertion sort here. A heap is faster but who cares the speed for this? */
@@ -133,6 +127,7 @@ TimeBinMgr::TimeBinMgr(Cosmology * CP, double TimeIC, double TimeMax, double no_
         // message(0, "outIdx: %d, outtime: %g, planeoutIdx: %d, planeouttime: %g.\n", outIdx, Sync.OutputListTimes[outIdx], planeoutIdx, Sync.PlaneOutputListTimes[planeoutIdx]);
         size_t j = 0;
         double a = Sync.OutputListTimes[i];
+        double loga = log(Sync.OutputListTimes[i]);
 
         if(a < TimeIC || a > TimeMax) {
             /*If the user inputs syncpoints outside the scope of the simulation, it can mess
@@ -142,25 +137,23 @@ TimeBinMgr::TimeBinMgr(Cosmology * CP, double TimeIC, double TimeMax, double no_
         }
 
         for(j = 0; j < SyncPoints.size(); j ++) {
-            if(a <= SyncPoints[j].a) {
+            if(loga <= SyncPoints[j].loga) {
                 break;
             }
         }
         /* found, so loga >= SyncPoints[j].loga */
-        if(a != SyncPoints[j].a) {
+        if(loga != SyncPoints[j].loga) {
             /* insert the item; */
-            tmpsync.a = a;
-            tmpsync.loga = log(a);
+            tmpsync.loga = loga;
             tmpsync.write_snapshot = false; /* by default no output here. */
             tmpsync.write_fof = false;
             tmpsync.calc_uvbg = false;
             tmpsync.write_plane = false;
             tmpsync.plane_snapnum = -1;
-            tmpsync.ti = 0;
             SyncPoints.insert(SyncPoints.begin() + j, tmpsync);
             //message(0,"added outlist syncpoint at a = %.3f, j = %ld, Ns = %ld\n",a,j,SyncPoints.size());
         }
-        if(SyncPoints[j].a > no_snapshot_until_time) {
+        if(SyncPoints[j].loga > log(no_snapshot_until_time)) {
             SyncPoints[j].write_snapshot = true;
             if(SnapshotWithFOF)
                 SyncPoints[j].write_fof = true;
@@ -181,7 +174,7 @@ TimeBinMgr::TimeBinMgr(Cosmology * CP, double TimeIC, double TimeMax, double no_
         }
 
         for(j = 0; j < SyncPoints.size(); j ++) {
-            if(a <= SyncPoints[j].a) {
+            if(loga <= SyncPoints[j].loga) {
                 break;
             }
         }
@@ -189,23 +182,17 @@ TimeBinMgr::TimeBinMgr(Cosmology * CP, double TimeIC, double TimeMax, double no_
         // to avoid setting sync points too close to each other (which can cause bad timestep errors)
         if(fabs(loga - SyncPoints[j].loga) > 1e-4) {
             /* insert a blank item with no snapshot output. */
-            tmpsync.a = a;
             tmpsync.loga = loga;
             tmpsync.write_snapshot = false; /* by default no output here. */
             tmpsync.write_fof = false;
             tmpsync.calc_uvbg = false;
             tmpsync.write_plane = false;
             tmpsync.plane_snapnum = -1;
-            tmpsync.ti = 0;
             SyncPoints.insert(SyncPoints.begin() + j, tmpsync);
             //message(0,"added outlist syncpoint at a = %.3f, j = %ld, Ns = %ld\n",a,j,SyncPoints.size());
         }
         SyncPoints[j].write_plane = 1;
         SyncPoints[j].plane_snapnum = i;
-    }
-
-    for(size_t i = 0; i < SyncPoints.size(); i++) {
-        SyncPoints[i].ti = (i * 1L) << (TIMEBINS);
     }
 
     //message(1,"NSyncPoints = %ld, OutputListLength = %ld , timemax = %.3f\n",NSyncPoints,Sync.OutputListLength,TimeMax);

--- a/libgadget/timebinmgr.h
+++ b/libgadget/timebinmgr.h
@@ -130,26 +130,22 @@ class TimeBinMgr {
     {
         /* Find current segment*/
         inttime_t lastsnap = Ti_Current >> TIMEBINS;
-        if(lastsnap >= SyncPoints.size()) {
+        if(lastsnap >= SyncPoints.size() -1 ) {
             lastsnap = SyncPoints.size() - 1;
         }
-        double last = SyncPoints[lastsnap].loga;
         inttime_t dti = Ti_Current & (TIMEBASE - 1);
         double logDTime = Dloga_interval_ti(Ti_Current);
         /* This is the same calculation as in loga_from_ti()*/
-        double loga = last + dti * logDTime;
+        double loga = SyncPoints[lastsnap].loga + dti * logDTime;
         /* ti_from_loga_snap() takes the lower syncpoint index of the segment
-         * which is lastsnap.
-         * We do this instead of using Ti_Current directly so that the floating
-         * point roundoff behaviour is the same.*/
+         * which is lastsnap.*/
         if(lastsnap >= SyncPoints.size()-1)
             lastsnap = SyncPoints.size() - 2;
-        inttime_t ti = ti_from_loga_snap(loga, lastsnap);
         /* If we cross into the next segment, advance to its upper index.*/
         if(lastsnap < SyncPoints.size() - 2 && SyncPoints[lastsnap+1].loga <= dloga + loga)
             lastsnap++;
         inttime_t tip = ti_from_loga_snap(dloga+loga, lastsnap);
-        return tip - ti;
+        return tip - Ti_Current;
     }
 
     double dloga_from_dti(inttime_t dti, const inttime_t Ti_Current)

--- a/libgadget/timebinmgr.h
+++ b/libgadget/timebinmgr.h
@@ -49,7 +49,7 @@ class TimeBinMgr {
 
     TimeBinMgr (Cosmology * CP, double TimeIC, double TimeMax, double no_snapshot_until_time, bool SnapshotWithFOF);
 
-    TimeBinMgr (): CP(NULL) {};
+    TimeBinMgr (): NSyncPoints(0), CP(NULL) {};
 
     /*! this function returns the next output time that is in the future of
     *  ti_curr; if none is find it return NULL, indication the run shall terminate.
@@ -57,7 +57,7 @@ class TimeBinMgr {
     SyncPoint *
     find_next_sync_point(inttime_t ti)
     {
-        for(auto i = 0; i < SyncPoints.size(); i ++) {
+        for(auto i = 0; i < NSyncPoints; i ++) {
             inttime_t syncti = (i * 1L) << (TIMEBINS);
             if(syncti > ti) {
                 return &SyncPoints[i];
@@ -77,7 +77,7 @@ class TimeBinMgr {
     SyncPoint *
     find_current_sync_point(inttime_t ti)
     {
-        for(auto i = 0; i < SyncPoints.size(); i ++) {
+        for(auto i = 0; i < NSyncPoints; i ++) {
             inttime_t syncti = (i * 1L) << (TIMEBINS);
             if(syncti == ti) {
                 return &SyncPoints[i];
@@ -91,8 +91,8 @@ class TimeBinMgr {
     loga_from_ti(inttime_t ti)
     {
         inttime_t lastsnap = ti >> TIMEBINS;
-        if(lastsnap >= SyncPoints.size()) {
-            lastsnap = SyncPoints.size() - 1;
+        if(lastsnap >= NSyncPoints) {
+            lastsnap = NSyncPoints - 1;
         }
         double last = SyncPoints[lastsnap].loga;
         inttime_t dti = ti & (TIMEBASE - 1);
@@ -105,7 +105,7 @@ class TimeBinMgr {
     {
         inttime_t i, ti;
         /* First syncpoint is simulation start*/
-        for(i = 1; i < SyncPoints.size() - 1; i++)
+        for(i = 1; i < NSyncPoints - 1; i++)
         {
             if(SyncPoints[i].loga > loga)
                 break;
@@ -136,8 +136,8 @@ class TimeBinMgr {
     {
         /* Find current segment*/
         inttime_t lastsnap = Ti_Current >> TIMEBINS;
-        if(lastsnap >= SyncPoints.size() -1 ) {
-            lastsnap = SyncPoints.size() - 1;
+        if(lastsnap >= NSyncPoints -1 ) {
+            lastsnap = NSyncPoints - 1;
         }
         inttime_t dti = Ti_Current & (TIMEBASE - 1);
         double logDTime = Dloga_interval_ti(Ti_Current);
@@ -145,10 +145,10 @@ class TimeBinMgr {
         double loga = SyncPoints[lastsnap].loga + dti * logDTime;
         /* ti_from_loga_snap() takes the lower syncpoint index of the segment
          * which is lastsnap.*/
-        if(lastsnap >= SyncPoints.size()-1)
-            lastsnap = SyncPoints.size() - 2;
+        if(lastsnap >= NSyncPoints-1)
+            lastsnap = NSyncPoints - 2;
         /* If we cross into the next segment, advance to its upper index.*/
-        if(lastsnap < SyncPoints.size() - 2 && SyncPoints[lastsnap+1].loga <= dloga + loga)
+        if(lastsnap < NSyncPoints - 2 && SyncPoints[lastsnap+1].loga <= dloga + loga)
             lastsnap++;
         inttime_t tip = ti_from_loga_snap(dloga+loga, lastsnap);
         return tip - Ti_Current;
@@ -217,11 +217,11 @@ class TimeBinMgr {
     }
 
     private:
-    /* Each integer time stores in the first 10 bits the snapshot number.
+    /* Each integer time stores in the first XX bits of the snapshot number.
     * Then the rest of the bits are the standard integer timeline,
-    * which should be a power-of-two hierarchy. We use this bit trick to speed up
-    * the dloga look up. But the additional math makes this quite fragile. */
-    std::vector<SyncPoint> SyncPoints;
+    * which should be a power-of-two hierarchy. */
+    size_t NSyncPoints;
+    std::unique_ptr<SyncPoint []> SyncPoints;
     Cosmology * CP;
 
     /*Gets Dloga / ti for the current integer timeline.
@@ -233,7 +233,7 @@ class TimeBinMgr {
 
         inttime_t lastsnap = ti >> TIMEBINS;
 
-        if(lastsnap >= SyncPoints.size() - 1) {
+        if(lastsnap >= NSyncPoints - 1) {
             /* stop advancing loga after the last sync point. */
             return 0;
         }

--- a/libgadget/timebinmgr.h
+++ b/libgadget/timebinmgr.h
@@ -2,6 +2,7 @@
 #define TIMEBINMGR_H
 
 #include <string>
+#include <vector>
 /* This file manages the integer timeline,
  * and converts from integers ti to double loga.*/
 
@@ -47,13 +48,10 @@ MYCUDAFN static inline inttime_t dti_from_timebin(int bin) {
 /*! table with desired sync points. All forces and phase space variables are synchonized to the same order. */
 class TimeBinMgr {
     public:
-    Cosmology * CP;
-    SyncPoint * SyncPoints;
-    int64_t NSyncPoints;    /* number of times stored in table of desired sync points */
 
     TimeBinMgr (Cosmology * CP, double TimeIC, double TimeMax, double no_snapshot_until_time, bool SnapshotWithFOF);
 
-    TimeBinMgr (): CP(NULL), SyncPoints(NULL), NSyncPoints(0) {};
+    TimeBinMgr (): CP(NULL) {};
 
     /*! this function returns the next output time that is in the future of
     *  ti_curr; if none is find it return NULL, indication the run shall terminate.
@@ -61,8 +59,7 @@ class TimeBinMgr {
     SyncPoint *
     find_next_sync_point(inttime_t ti)
     {
-        int64_t i;
-        for(i = 0; i < NSyncPoints; i ++) {
+        for(auto i = 0; i < SyncPoints.size(); i ++) {
             if(SyncPoints[i].ti > ti) {
                 return &SyncPoints[i];
             }
@@ -75,8 +72,7 @@ class TimeBinMgr {
     SyncPoint *
     find_current_sync_point(inttime_t ti)
     {
-        int64_t i;
-        for(i = 0; i < NSyncPoints; i ++) {
+        for(auto i = 0; i < SyncPoints.size(); i ++) {
             if(SyncPoints[i].ti == ti) {
                 return &SyncPoints[i];
             }
@@ -85,12 +81,12 @@ class TimeBinMgr {
     }
 
     /*Convert an integer to and from loga*/
-    MYCUDAFN double
+    double
     loga_from_ti(inttime_t ti)
     {
         inttime_t lastsnap = ti >> TIMEBINS;
-        if(lastsnap > NSyncPoints) {
-            lastsnap = NSyncPoints -1;
+        if(lastsnap >= SyncPoints.size()) {
+            lastsnap = SyncPoints.size() - 1;
         }
         double last = SyncPoints[lastsnap].loga;
         inttime_t dti = ti & (TIMEBASE - 1);
@@ -98,12 +94,12 @@ class TimeBinMgr {
         return last + dti * logDTime;
     }
 
-    MYCUDAFN inttime_t
+    inttime_t
     ti_from_loga(double loga)
     {
         inttime_t i, ti;
         /* First syncpoint is simulation start*/
-        for(i = 1; i < NSyncPoints - 1; i++)
+        for(i = 1; i < SyncPoints.size() - 1; i++)
         {
             if(SyncPoints[i].loga > loga)
                 break;
@@ -135,8 +131,8 @@ class TimeBinMgr {
     {
         /* Find current segment*/
         inttime_t lastsnap = Ti_Current >> TIMEBINS;
-        if(lastsnap >= NSyncPoints) {
-            lastsnap = NSyncPoints - 1;
+        if(lastsnap >= SyncPoints.size()) {
+            lastsnap = SyncPoints.size() - 1;
         }
         double last = SyncPoints[lastsnap].loga;
         inttime_t dti = Ti_Current & (TIMEBASE - 1);
@@ -149,11 +145,11 @@ class TimeBinMgr {
          * We do this instead of using Ti_Current directly so that the floating
          * point roundoff behaviour is the same.*/
         inttime_t upper = lastsnap + 1;
-        if(upper >= NSyncPoints)
-            upper = NSyncPoints - 1;
+        if(upper >= SyncPoints.size())
+            upper = SyncPoints.size() - 1;
         inttime_t ti = ti_from_loga_snap(loga, upper);
         /* If we cross into the next segment, advance to its upper index.*/
-        if(upper < NSyncPoints-1 && SyncPoints[upper].loga <= dloga + loga)
+        if(upper < SyncPoints.size() - 1 && SyncPoints[upper].loga <= dloga + loga)
             upper++;
         inttime_t tip = ti_from_loga_snap(dloga+loga, upper);
         return tip - ti;
@@ -173,14 +169,14 @@ class TimeBinMgr {
         return Dloga * dti * sign;
     }
     /*Get dloga from a timebin*/
-    MYCUDAFN double get_dloga_for_bin(int timebin, const inttime_t Ti_Current)
+    double get_dloga_for_bin(int timebin, const inttime_t Ti_Current)
     {
         double logDTime = Dloga_interval_ti(Ti_Current);
         return dti_from_timebin(timebin) * logDTime;
     }
 
     /* Get the current scale factor*/
-    MYCUDAFN double
+    double
     get_atime(const inttime_t Ti_Current) {
         return exp(loga_from_ti(Ti_Current));
     }
@@ -226,17 +222,19 @@ class TimeBinMgr {
     * Then the rest of the bits are the standard integer timeline,
     * which should be a power-of-two hierarchy. We use this bit trick to speed up
     * the dloga look up. But the additional math makes this quite fragile. */
+    std::vector<SyncPoint> SyncPoints;
+    Cosmology * CP;
 
     /*Gets Dloga / ti for the current integer timeline.
     * Valid up to the next snapshot, after which it will change*/
-    MYCUDAFN double Dloga_interval_ti(inttime_t ti)
+    double Dloga_interval_ti(inttime_t ti)
     {
         /* FIXME: This uses the bit tricks because it has to be fast
         * -- till we clean up the calls to loga_from_ti; then we can avoid bit tricks. */
 
         inttime_t lastsnap = ti >> TIMEBINS;
 
-        if(lastsnap >= NSyncPoints - 1) {
+        if(lastsnap >= SyncPoints.size() - 1) {
             /* stop advancing loga after the last sync point. */
             return 0;
         }

--- a/libgadget/timebinmgr.h
+++ b/libgadget/timebinmgr.h
@@ -67,6 +67,12 @@ class TimeBinMgr {
         return NULL;
     }
 
+    inttime_t
+    find_next_ti_sync(inttime_t ti)
+    {
+        return ((ti >> TIMEBINS) + 1L) << (TIMEBINS);
+    }
+
     /* This function finds if ti is a sync point; if so returns the sync point;
     * otherwise, NULL. We check if we shall write a snapshot with this. */
     SyncPoint *

--- a/libgadget/timebinmgr.h
+++ b/libgadget/timebinmgr.h
@@ -116,12 +116,11 @@ class TimeBinMgr {
     inttime_t
     ti_from_loga_snap(double loga, inttime_t lastsnap)
     {
-        /*If loop didn't trigger, i == All.NSyncPointTimes-1*/
-        double logDTime = (SyncPoints[lastsnap].loga - SyncPoints[lastsnap-1].loga)/TIMEBASE;
-        inttime_t ti = (lastsnap-1) << TIMEBINS;
+        double logDTime = (SyncPoints[lastsnap+1].loga - SyncPoints[lastsnap].loga)/TIMEBASE;
+        inttime_t ti = (lastsnap) << TIMEBINS;
         /* Note this means if we overrun the end of the timeline,
         * we still get something reasonable*/
-        ti += (loga - SyncPoints[lastsnap-1].loga)/logDTime;
+        ti += (loga - SyncPoints[lastsnap].loga)/logDTime;
         return ti;
     }
 
@@ -139,19 +138,17 @@ class TimeBinMgr {
         double logDTime = Dloga_interval_ti(Ti_Current);
         /* This is the same calculation as in loga_from_ti()*/
         double loga = last + dti * logDTime;
-        /* ti_from_loga_snap() takes the upper syncpoint index of the segment
-         * (it uses index-1 as the segment base), whereas lastsnap is the lower
-         * index of the current segment. So the current segment is [lastsnap, lastsnap+1].
+        /* ti_from_loga_snap() takes the lower syncpoint index of the segment
+         * which is lastsnap.
          * We do this instead of using Ti_Current directly so that the floating
          * point roundoff behaviour is the same.*/
-        inttime_t upper = lastsnap + 1;
-        if(upper >= SyncPoints.size())
-            upper = SyncPoints.size() - 1;
-        inttime_t ti = ti_from_loga_snap(loga, upper);
+        if(lastsnap >= SyncPoints.size()-1)
+            lastsnap = SyncPoints.size() - 2;
+        inttime_t ti = ti_from_loga_snap(loga, lastsnap);
         /* If we cross into the next segment, advance to its upper index.*/
-        if(upper < SyncPoints.size() - 1 && SyncPoints[upper].loga <= dloga + loga)
-            upper++;
-        inttime_t tip = ti_from_loga_snap(dloga+loga, upper);
+        if(lastsnap < SyncPoints.size() - 2 && SyncPoints[lastsnap+1].loga <= dloga + loga)
+            lastsnap++;
+        inttime_t tip = ti_from_loga_snap(dloga+loga, lastsnap);
         return tip - ti;
     }
 

--- a/libgadget/timebinmgr.h
+++ b/libgadget/timebinmgr.h
@@ -29,14 +29,12 @@ typedef struct SyncPoint SyncPoint;
 
 struct SyncPoint
 {
-    double a;
     double loga;
+    int plane_snapnum;  //! The snapshot number for the plane
     bool write_snapshot;
     bool write_fof;
     bool calc_uvbg;  //! Calculate the UV background
     bool write_plane;  //! Write a plane
-    int plane_snapnum;  //! The snapshot number for the plane
-    inttime_t ti;
 };
 
 /*Get the dti from the timebin*/
@@ -60,7 +58,8 @@ class TimeBinMgr {
     find_next_sync_point(inttime_t ti)
     {
         for(auto i = 0; i < SyncPoints.size(); i ++) {
-            if(SyncPoints[i].ti > ti) {
+            inttime_t syncti = (i * 1L) << (TIMEBINS);
+            if(syncti > ti) {
                 return &SyncPoints[i];
             }
         }
@@ -79,7 +78,8 @@ class TimeBinMgr {
     find_current_sync_point(inttime_t ti)
     {
         for(auto i = 0; i < SyncPoints.size(); i ++) {
-            if(SyncPoints[i].ti == ti) {
+            inttime_t syncti = (i * 1L) << (TIMEBINS);
+            if(syncti == ti) {
                 return &SyncPoints[i];
             }
         }

--- a/libgadget/timebinmgr.h
+++ b/libgadget/timebinmgr.h
@@ -117,16 +117,49 @@ class TimeBinMgr {
         return ti;
     }
 
-    /*Convert changes in loga to and from ti*/
-    MYCUDAFN inttime_t
-    dti_from_dloga(double loga, const inttime_t Ti_Current)
+    inttime_t
+    ti_from_loga_snap(double loga, inttime_t lastsnap)
     {
-        inttime_t ti = ti_from_loga(loga_from_ti(Ti_Current));
-        inttime_t tip = ti_from_loga(loga+loga_from_ti(Ti_Current));
+        /*If loop didn't trigger, i == All.NSyncPointTimes-1*/
+        double logDTime = (SyncPoints[lastsnap].loga - SyncPoints[lastsnap-1].loga)/TIMEBASE;
+        inttime_t ti = (lastsnap-1) << TIMEBINS;
+        /* Note this means if we overrun the end of the timeline,
+        * we still get something reasonable*/
+        ti += (loga - SyncPoints[lastsnap-1].loga)/logDTime;
+        return ti;
+    }
+
+    /*Convert changes in loga to and from ti*/
+    inttime_t
+    dti_from_dloga(double dloga, const inttime_t Ti_Current)
+    {
+        /* Find current segment*/
+        inttime_t lastsnap = Ti_Current >> TIMEBINS;
+        if(lastsnap >= NSyncPoints) {
+            lastsnap = NSyncPoints - 1;
+        }
+        double last = SyncPoints[lastsnap].loga;
+        inttime_t dti = Ti_Current & (TIMEBASE - 1);
+        double logDTime = Dloga_interval_ti(Ti_Current);
+        /* This is the same calculation as in loga_from_ti()*/
+        double loga = last + dti * logDTime;
+        /* ti_from_loga_snap() takes the upper syncpoint index of the segment
+         * (it uses index-1 as the segment base), whereas lastsnap is the lower
+         * index of the current segment. So the current segment is [lastsnap, lastsnap+1].
+         * We do this instead of using Ti_Current directly so that the floating
+         * point roundoff behaviour is the same.*/
+        inttime_t upper = lastsnap + 1;
+        if(upper >= NSyncPoints)
+            upper = NSyncPoints - 1;
+        inttime_t ti = ti_from_loga_snap(loga, upper);
+        /* If we cross into the next segment, advance to its upper index.*/
+        if(upper < NSyncPoints-1 && SyncPoints[upper].loga <= dloga + loga)
+            upper++;
+        inttime_t tip = ti_from_loga_snap(dloga+loga, upper);
         return tip - ti;
     }
 
-    MYCUDAFN double dloga_from_dti(inttime_t dti, const inttime_t Ti_Current)
+    double dloga_from_dti(inttime_t dti, const inttime_t Ti_Current)
     {
         double Dloga = Dloga_interval_ti(Ti_Current);
         int sign = 1;

--- a/libgadget/timestep.cpp
+++ b/libgadget/timestep.cpp
@@ -1225,13 +1225,8 @@ get_PM_timestep_ti(const DriftKickTimes * const times, TimeBinMgr * timebinmgr, 
     inttime_t dti = timebinmgr->dti_from_dloga(dloga, times->Ti_Current);
     dti = round_down_power_of_two(dti);
 
-    SyncPoint * next = timebinmgr->find_next_sync_point(times->Ti_Current);
-    if(next == NULL)
-        endrun(0, "Trying to go beyond the last sync point. This happens only at TimeMax \n");
-
     /* go no more than the next sync point */
-    inttime_t dti_max = next->ti - times->PM_kick;
-
+    inttime_t dti_max = timebinmgr->find_next_ti_sync(times->Ti_Current) - times->PM_kick;
     if(dti > dti_max)
         dti = dti_max;
     return dti;


### PR DESCRIPTION
Improve the sync point initialisation. Before we do this we need to speed up dti_from_dloga, which does a series of unneeded linear scans.