### PR TITLE
Fix barycentric rational namespace

### DIFF
--- a/libgadget/neutrinos_lra.cpp
+++ b/libgadget/neutrinos_lra.cpp
@@ -710,7 +710,7 @@ void get_delta_nu(Cosmology * CP, const _delta_tot_table * const d_tot, const do
                 dtot_spline = [sp](const double x) { return (*sp)(x); };
             }
             else {
-                auto sp = std::make_shared<boost::math::interpolators::barycentric_rational<double>>(std::move(loga),std::move(delta_tot_k), Na-1);
+                auto sp = std::make_shared<boost::math::barycentric_rational<double>>(std::move(loga),std::move(delta_tot_k), Na-1);
                 dtot_spline = [sp](const double x) { return (*sp)(x); };
             }
             /**integration kernel for get_delta_nu*/


### PR DESCRIPTION
Fixes the Boost namespace used for barycentric_rational in libgadget/neutrinos_lra.cpp.

  The code included the correct Boost header but referenced the type as boost::math::interpolators::barycentric_rational. The class is actually declared in boost::math, so this caused compilation to fail. The following std::function error was a downstream consequence of the unresolved type.